### PR TITLE
TP Command, fix for integer coords

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -36,9 +36,9 @@ QBCore.Commands.Add("tp", "TP To Player or Coords (Admin Only)", {{name="id/x", 
 	else
 		if args[1] ~= nil and args[2] ~= nil and args[3] ~= nil then
 			local player = GetPlayerPed(source)
-			local x = tonumber(args[1])
-			local y = tonumber(args[2])
-			local z = tonumber(args[3])
+			local x = tonumber(args[1]) + 0.0
+			local y = tonumber(args[2]) + 0.0
+			local z = tonumber(args[3]) + 0.0
 			if (x ~= 0) and (y ~= 0) and (z ~= 0) then
 				TriggerClientEvent('QBCore:Command:TeleportToCoords', source, x, y, z)
 			else


### PR DESCRIPTION
Since I couldn't find the toFloat function in Lua, I tried to fix the problem by adding 0.0 as the most convenient. When we enter this integer coordinate, it will prevent the game from breaking.