### PR TITLE
Money duping exploit fix

### DIFF
--- a/client/loops.lua
+++ b/client/loops.lua
@@ -46,3 +46,13 @@ Citizen.CreateThread(function()
 		end
 	end
 end)
+
+
+Citizen.CreateThread(function()
+	while true do
+		Citizen.Wait(500 * 3600) -- 30 MIN LOOP FOR PAYCHECK
+		if isLoggedIn then
+			TriggerServerEvent('QBCore:server:givepaycheck')
+		end
+	end
+end)

--- a/server/events.lua
+++ b/server/events.lua
@@ -273,3 +273,14 @@ AddEventHandler('QBCore:Command:CheckOwnedVehicle', function(VehiclePlate)
 		end)
 	end
 end)
+
+
+RegisterServerEvent('QBCore:server:givepaycheck')
+AddEventHandler('QBCore:server:givepaycheck', function()
+	local src = source
+	local player = QBCore.Functions.GetPlayer(src)
+	
+	if player then
+		player.Functions.AddMoney("bank", Player.PlayerData.job.payment)
+	end
+end)

--- a/server/events.lua
+++ b/server/events.lua
@@ -101,7 +101,6 @@ AddEventHandler('QBCore:UpdatePlayer', function(data)
 		Player.Functions.SetMetaData("thirst", newThirst)
 		Player.Functions.SetMetaData("hunger", newHunger)
 
-		Player.Functions.AddMoney("bank", Player.PlayerData.job.payment)
 		TriggerClientEvent('QBCore:Notify', src, "You received your paycheck of $"..Player.PlayerData.job.payment)
 		TriggerClientEvent("hud:client:UpdateNeeds", src, newHunger, newThirst)
 


### PR DESCRIPTION
Removed the function trigger to give player money from the logout event

Added new loop on the client-side that will run every 30min and if the player is logged in it will trigger server event for giving the paycheck

Created a new event that will give a paycheck to the player