### PR TITLE
fix for Xenon lights color not set when retrieve from the garage

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -576,8 +576,8 @@ QBCore.Functions.SetVehicleProperties = function(vehicle, props)
 			ToggleVehicleMod(vehicle,  22, props.modXenon)
 		end
 
-		if props.modXenonColor ~= nil then
-			SetVehicleXenonLightsColour(vehicle, props.modXenonColor)
+		if props.xenonColor ~= nil then
+			SetVehicleXenonLightsColor(vehicle, props.xenonColor)
 		end
 
 		if props.modFrontWheels ~= nil then


### PR DESCRIPTION
Added new native and fixed a call for a non exist json parameter.