### PR TITLE
FloatingNotification

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -38,6 +38,14 @@ QBCore.Functions.DrawText3D = function(x, y, z, text)
     ClearDrawOrigin()
 end
 
+QBCore.Functions.FloatingNotification = function(msg, x,y,z)
+	AddTextEntry('FloatingNotification', msg)
+	SetFloatingHelpTextWorldPosition(1, x, y, z)
+	SetFloatingHelpTextStyle(1, 1, 2, -1, 3, 0)
+	BeginTextCommandDisplayHelp('FloatingNotification')
+	EndTextCommandDisplayHelp(2, false, false, -1)
+end
+
 QBCore.Functions.GetCoords = function(entity)
     local coords = GetEntityCoords(entity, false)
     local heading = GetEntityHeading(entity)


### PR DESCRIPTION
To replace the classic drawtext call native `SetFloatingHelpTextWorldPosition`

![floating](https://user-images.githubusercontent.com/86290612/123932289-964c4c00-d991-11eb-9175-6b54d6a439f7.png)

in `qb-core\client\functions.lua`

```LUA
QBCore.Functions.FloatingNotification = function(msg, x,y,z)
    AddTextEntry('FloatingNotification', msg)
    SetFloatingHelpTextWorldPosition(1, x, y, z)
    SetFloatingHelpTextStyle(1, 1, 2, -1, 3, 0)
    BeginTextCommandDisplayHelp('FloatingNotification')
    EndTextCommandDisplayHelp(2, false, false, -1)
end
```

example in client file: 
```LUA
QBCore.Functions.FloatingNotification('[~b~E~w~] - ~r~Text ~w~Here ~g~ASD', x, y, z + 0.2)
```

or you can call the function in all client.lua individually

```LUA
function FloatingNotification (msg, x,y,z)
    AddTextEntry('FloatingNotification ', msg)
    SetFloatingHelpTextWorldPosition(1, x, y, z)
    SetFloatingHelpTextStyle(1, 1, 2, -1, 3, 0)
    BeginTextCommandDisplayHelp('FloatingNotification ')
    EndTextCommandDisplayHelp(2, false, false, -1)
end
```

example in client file:
```LUA
FloatingNotification('[~b~E~w~] - ~r~Text ~w~Here ~g~ASD', x, y, z + 0.2)
```