### PR TITLE
chore(lua54): utilize Lua version 5.4 runtime

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -32,6 +32,8 @@ ui_page {
 	'html/ui.html'
 }
 
+lua54 'yes'
+
 files {
 	'html/ui.html',
 	'html/css/main.css',


### PR DESCRIPTION
This version of Lua includes improved changes to GC, better pseudo-randomness with `math.random()` (no longer requiring a seed to display even an ounce of randomness), and `const` keyword for all the immutable fellas out there.