### PR TITLE
feat(server/player): PlayerLoaded event for third party resources

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -423,9 +423,12 @@ QBCore.Player.CreatePlayer = function(PlayerData)
 	self.Functions.Save = function()
 		QBCore.Player.Save(self.PlayerData.source)
 	end
-	
+
 	QBCore.Players[self.PlayerData.source] = self
 	QBCore.Player.Save(self.PlayerData.source)
+
+	-- At this point we are safe to emit new instance to third party resource for load handling
+	TriggerEvent('QBCore:Server:PlayerLoaded', self)
 	self.Functions.UpdatePlayerData()
 end
 


### PR DESCRIPTION
Third party resources like NPWD need the Player instance as soon as available for internal player map handling. This establishes parity with ESX's player load event.