### PR TITLE
Add return "closestDistance" for ClosestVehicle

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -158,7 +158,7 @@ QBCore.Functions.GetClosestVehicle = function(coords)
 			closestDistance = distance
 		end
 	end
-	return closestVehicle
+	return closestVehicle,closestDistance
 end
 
 QBCore.Functions.GetClosestPed = function(coords, ignoreList) 


### PR DESCRIPTION
QBCore.Functions.GetClosestVehicle 
With this small addition, we can operate according to the distance of the vehicle in the same function. We are returning a value that already exists in it.

Please let me know if there is a better solution.