### PR TITLE
add 	QBCore.Players[source].Functions.Save()

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -475,6 +475,7 @@ QBCore.Player.Logout = function(source)
 	TriggerClientEvent('QBCore:Client:OnPlayerUnload', source)
 	TriggerClientEvent("QBCore:Player:UpdatePlayerData", source)
 	Citizen.Wait(200)
+	QBCore.Players[source].Functions.Save()
 	QBCore.Players[source] = nil
 end
 


### PR DESCRIPTION
Thanks to this addition, we save when the player exits the game. This fixes some duplication issues.
And when we exit the game, we save everything.

Resolves duplication issues when making changes to his/her/player inventory and outputting it openly.