### PR TITLE
Configurable hunger and thirst rate.

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -11,6 +11,8 @@ QBConfig.Money.PayCheckTimeOut = 10 -- The time in minutes that it will give the
 QBConfig.Player = {}
 QBConfig.Player.MaxWeight = 120000 -- Max weight a player can carry (currently 120kg, written in grams)
 QBConfig.Player.MaxInvSlots = 41 -- Max inventory slots for a player
+QBConfig.Player.HungerRate = 4.2 -- Rate at which hunger goes down.
+QBConfig.Player.ThirstRate = 3.8 -- Rate at which thirst goes down.
 QBConfig.Player.Bloodtypes = {
     "A+",
     "A-",

--- a/server/events.lua
+++ b/server/events.lua
@@ -93,8 +93,8 @@ AddEventHandler('QBCore:UpdatePlayer', function(data)
 	local Player = QBCore.Functions.GetPlayer(src)
 	if Player ~= nil then
 		Player.PlayerData.position = data.position
-		local newHunger = Player.PlayerData.metadata["hunger"] - 4.2
-		local newThirst = Player.PlayerData.metadata["thirst"] - 3.8
+		local newHunger = Player.PlayerData.metadata["hunger"] - QBCore.Config.Player.HungerRate
+		local newThirst = Player.PlayerData.metadata["thirst"] - QBCore.Config.Player.ThirstRate
 		if newHunger <= 0 then newHunger = 0 end
 		if newThirst <= 0 then newThirst = 0 end
 		Player.Functions.SetMetaData("thirst", newThirst)


### PR DESCRIPTION
Make the rate that hunger and thirst deplete configurable, via `QBConfig.Player.HungerRate` and `QBConfig.Player.ThirstRate` respectively.