### PR TITLE
Optimize Command Suggestions

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -14,12 +14,20 @@ end
 
 QBCore.Commands.Refresh = function(source)
 	local Player = QBCore.Functions.GetPlayer(tonumber(source))
+	local suggestions = {}
 	if Player ~= nil then
 		for command, info in pairs(QBCore.Commands.List) do
 			if QBCore.Functions.HasPermission(source, "god") or QBCore.Functions.HasPermission(source, QBCore.Commands.List[command].permission) then
-				TriggerClientEvent('chat:addSuggestion', source, "/"..command, info.help, info.arguments)
+				--TriggerClientEvent('chat:addSuggestion', source, "/"..command, info.help, info.arguments)
+				table.insert(suggestions, {
+					name = '/' .. command,
+					help = info.help,
+					params = info.arguments
+				})
 			end
 		end
+		
+		TriggerClientEvent('chat:addSuggestions', tonumber(source), suggestions)
 	end
 end
 


### PR DESCRIPTION
Rather than calling 100 client-events inside of a for loop it creates a table of commands and send the table across to the client in 1 event.

This has resulted in big issues on a server with 50 players hence why I had patched this out. 