### PR TITLE
fix closestObject/closestVehicle coords

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -142,9 +142,7 @@ end
 
 function QBCore.Functions.GetClosestPlayer(coords)
     local ped = PlayerPedId()
-    if coords == nil then
-        coords = GetEntityCoords(ped)
-	end
+    local coords = coords or GetEntityCoords(ped)
     local closestPlayers = QBCore.Functions.GetPlayersFromCoords(coords)
     local closestDistance = -1
     local closestPlayer = -1
@@ -183,10 +181,7 @@ function QBCore.Functions.GetClosestVehicle(coords)
 	local vehicles        = GetGamePool('CVehicle')
 	local closestDistance = -1
 	local closestVehicle  = -1
-	local coords          = coords
-	if coords == nil then
-		coords = GetEntityCoords(ped)
-	end
+	local coords = coords or GetEntityCoords(ped)
 	for i=1, #vehicles, 1 do
 		local vehicleCoords = GetEntityCoords(vehicles[i])
 		local distance = #(vehicleCoords - coords)
@@ -196,7 +191,7 @@ function QBCore.Functions.GetClosestVehicle(coords)
 			closestDistance = distance
 		end
 	end
-	return closestVehicle,closestDistance
+	return closestVehicle, closestDistance
 end
 
 function QBCore.Functions.GetClosestObject(coords)
@@ -204,10 +199,7 @@ function QBCore.Functions.GetClosestObject(coords)
     local objects = GetGamePool('CObject')
     local closestDistance = -1
     local closestObject = -1
-    local coords          = coords
-	if coords == nil then
-		coords = GetEntityCoords(ped)
-	end
+    local coords = coords or GetEntityCoords(ped)
     for i = 1, #objects, 1 do
         local objectCoords = GetEntityCoords(objects[i])
         local distance = #(objectCoords - coords)
@@ -216,7 +208,7 @@ function QBCore.Functions.GetClosestObject(coords)
             closestDistance = distance
         end
     end
-    return closestObject,closestDistance
+    return closestObject, closestDistance
 end
 
 -- Vehicle

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -177,29 +177,37 @@ function QBCore.Functions.GetPlayersFromCoords(coords, distance)
     return closePlayers
 end
 
-function QBCore.Functions.GetClosestVehicle()
-    local ped = PlayerPedId()
-    local coords = GetEntityCoords(ped)
-    local vehicles = GetGamePool('CVehicle')
-    local closestDistance = -1
-    local closestVehicle = -1
-    for i = 1, #vehicles, 1 do
-        local vehicleCoords = GetEntityCoords(vehicles[i])
-        local distance = #(vehicleCoords - coords)
-        if closestDistance == -1 or closestDistance > distance then
-            closestVehicle = vehicles[i]
-            closestDistance = distance
-        end
-    end
-    return closestVehicle, closestDistance
+function QBCore.Functions.GetClosestVehicle(coords)
+	local vehicles        = GetGamePool('CVehicle')
+	local closestDistance = -1
+	local closestVehicle  = -1
+	local coords          = coords
+
+	if coords == nil then
+		local playerPed = PlayerPedId()
+		coords = GetEntityCoords(playerPed)
+	end
+	for i=1, #vehicles, 1 do
+		local vehicleCoords = GetEntityCoords(vehicles[i])
+		local distance = #(vehicleCoords - coords)
+
+		if closestDistance == -1 or closestDistance > distance then
+			closestVehicle  = vehicles[i]
+			closestDistance = distance
+		end
+	end
+	return closestVehicle,closestDistance
 end
 
-function QBCore.Functions.GetClosestObject()
+function QBCore.Functions.GetClosestObject(coords)
     local ped = PlayerPedId()
-    local coords = GetEntityCoords(ped)
     local objects = GetGamePool('CObject')
     local closestDistance = -1
     local closestObject = -1
+	local coords          = coords
+	if coords == nil then
+		coords = GetEntityCoords(ped)
+	end
     for i = 1, #objects, 1 do
         local objectCoords = GetEntityCoords(objects[i])
         local distance = #(objectCoords - coords)
@@ -208,7 +216,7 @@ function QBCore.Functions.GetClosestObject()
             closestDistance = distance
         end
     end
-    return closestObject, closestDistance
+    return closestObject,closestDistance
 end
 
 -- Vehicle

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -141,10 +141,11 @@ function QBCore.Functions.GetClosestPed(coords, ignoreList)
 end
 
 function QBCore.Functions.GetClosestPlayer(coords)
+    local ped = PlayerPedId()
     if coords == nil then
-        coords = GetEntityCoords(PlayerPedId())
+        coords = GetEntityCoords(ped)
 	end
-	local closestPlayers = QBCore.Functions.GetPlayersFromCoords(coords)
+    local closestPlayers = QBCore.Functions.GetPlayersFromCoords(coords)
     local closestDistance = -1
     local closestPlayer = -1
     for i=1, #closestPlayers, 1 do
@@ -178,14 +179,13 @@ function QBCore.Functions.GetPlayersFromCoords(coords, distance)
 end
 
 function QBCore.Functions.GetClosestVehicle(coords)
+	local ped = PlayerPedId()
 	local vehicles        = GetGamePool('CVehicle')
 	local closestDistance = -1
 	local closestVehicle  = -1
 	local coords          = coords
-
 	if coords == nil then
-		local playerPed = PlayerPedId()
-		coords = GetEntityCoords(playerPed)
+		coords = GetEntityCoords(ped)
 	end
 	for i=1, #vehicles, 1 do
 		local vehicleCoords = GetEntityCoords(vehicles[i])
@@ -204,7 +204,7 @@ function QBCore.Functions.GetClosestObject(coords)
     local objects = GetGamePool('CObject')
     local closestDistance = -1
     local closestObject = -1
-	local coords          = coords
+    local coords          = coords
 	if coords == nil then
 		coords = GetEntityCoords(ped)
 	end


### PR DESCRIPTION
In the previous version we could check the coordinates. In this, we automatically get the coordinate of the player. I hadn't noticed this yesterday when I was testing it. I am attaching this fix. Available in before "Major update" version.

I saw that this caused bugs in some scripts today. So I am posting this update it solves the problem.


**_----------------------_**
**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest) **YES**
- Does your code fit the style guidelines? [yes/no] **YES**
- Does your PR fit the contribution guidelines? [yes/no] **YES**
