### PR TITLE
refactor(debug): Replace clunky table print with Avarian's

### DIFF
--- a/server/debug.lua
+++ b/server/debug.lua
@@ -1,28 +1,38 @@
-RegisterServerEvent('QBCore:DebugSomething', function(resource, obj, depth)
-    print('\x1b[4m\x1b[36m[' .. resource .. ':DEBUG]\x1b[0m')
-    if type(obj) == 'string' then
-        print(string.format('%q', obj))
-    elseif type(obj) == 'table' then
-        local str = '{'
-        for k, v in pairs(obj) do
-            if type(v) == 'table' then
-                for ik, iv in pairs(v) do
-                    str = str .. '\n[' .. k .. '] -> [' .. ik .. '] -> ' .. tostring(iv)
-                end
-            else
-                str = str .. '\n[' .. k .. '] -> ' .. tostring(v)
-            end
+local function tPrint(tbl, indent)
+    indent = indent or 0
+    for k, v in pairs(tbl) do
+        local tblType = type(v)
+        local formatting = ("%s ^3%s:^0"):format(string.rep("  ", indent), k)
+
+        if tblType == "table" then
+            print(formatting)
+            tPrint(v, indent + 1)
+        elseif tblType == 'boolean' then
+            print(("%s^1 %s ^0"):format(formatting,v))
+        elseif tblType == "function" then
+            print(("%s^9 %s ^0"):format(formatting,v))
+        elseif tblType == 'number' then
+            print(("%s^5 %s ^0"):format(formatting,v))
+        elseif tblType == 'string' then
+            print(("%s ^2'%s' ^0"):format(formatting,v))
+        else
+            print(("%s^2 %s ^0"):format(formatting,v))
         end
-        print(str .. '\n}')
-    else
-        local success, value = pcall(function() return tostring(obj) end)
-        print((success and value or '<!!error in __tostring metamethod!!>'))
     end
-    print('\x1b[4m\x1b[36mEND OF DEBUG\x1b[0m')
+end
+
+RegisterServerEvent('QBCore:DebugSomething', function(table, indent)
+    local resource = GetInvokingResource() or "qb-core"
+
+    print(('\x1b[4m\x1b[36m[ %s : DEBUG]\x1b[0m'):format(resource))
+
+    tPrint(table, indent)
+
+    print('\x1b[4m\x1b[36m[ END DEBUG ]\x1b[0m')
 end)
 
-function QBCore.Debug(resource, obj, depth)
-    TriggerEvent('QBCore:DebugSomething', resource, obj, depth)
+function QBCore.Debug(table, indent)
+    TriggerEvent('QBCore:DebugSomething', table, indent)
 end
 
 function QBCore.ShowError(resource, msg)


### PR DESCRIPTION
**Describe Pull request**
Replaces QBCore.Debug with a new recursive function with colour coded types by @AvarianKnight


- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
Code used to test:

```lua
local QBCore = exports['qb-core']:GetSharedObject()
QBCore.Debug(QBCore.Shared.StarterItems)
```
Output: 
![](https://i.gyazo.com/b803d4504defb726861863722a36fbc1.png)

- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
