### PR TITLE
feat (Functions/Math): Added Precision Rounding so that people can round to nearest decimal efficiently.

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -451,3 +451,22 @@ function QBCore.Functions.SetVehicleProperties(vehicle, props)
 		end
 	end
 end
+
+-- Extra Math Functions
+
+-- Math Rounding Credits: http://lua-users.org/wiki/SimpleRound
+function QBCore.Functions.Math.Sign(v)
+	return (v >= 0 and 1) or -1
+end
+
+-- Math Rounding Credits: http://lua-users.org/wiki/SimpleRound
+-- Usage:
+-- QBCore.Functions.Math.Round(119.68, 0.01) = 119.68
+-- QBCore.Functions.Math.Round(119.68, 0.1) = 119.7
+-- QBCore.Functions.Math.Round(119.68) = 120
+-- QBCore.Functions.Math.Round(119.68, 100) = 100
+-- QBCore.Functions.Math.Round(119.68, 1000) = 0
+function QBCore.Functions.Math.Round(v, bracket)
+	bracket = bracket or 1
+	return QBCore.Functions.Math.Sign(v/bracket + QBCore.Functions.Math.Sign(v) * 0.5) * bracket
+end

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -299,3 +299,22 @@ function QBCore.Functions.IsLicenseInUse(license)
     end
     return false
 end
+
+-- Extra Math Functions
+
+-- Math Rounding Credits: http://lua-users.org/wiki/SimpleRound
+function QBCore.Functions.Math.Sign(v)
+	return (v >= 0 and 1) or -1
+end
+
+-- Math Rounding Credits: http://lua-users.org/wiki/SimpleRound
+-- Usage:
+-- QBCore.Functions.Math.Round(119.68, 0.01) = 119.68
+-- QBCore.Functions.Math.Round(119.68, 0.1) = 119.7
+-- QBCore.Functions.Math.Round(119.68) = 120
+-- QBCore.Functions.Math.Round(119.68, 100) = 100
+-- QBCore.Functions.Math.Round(119.68, 1000) = 0
+function QBCore.Functions.Math.Round(v, bracket)
+	bracket = bracket or 1
+	return QBCore.Functions.Math.Sign(v/bracket + QBCore.Functions.Math.Sign(v) * 0.5) * bracket
+end


### PR DESCRIPTION
**Describe Pull request**
So the Lua native math library does not seem to include rounding to decimal functionality e.g; math.round(0.02314, 2), I implemented a function to handle that.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? ✅
- Does your code fit the style guidelines? ✅
- Does your PR fit the contribution guidelines? ✅