### PR TITLE
Non qbcore commands couldn't be called

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -97,3 +97,13 @@ end)
 RegisterNetEvent('QBCore:Client:UseItem', function(item)
     TriggerServerEvent('QBCore:Server:UseItem', item)
 end)
+
+RegisterNetEvent('QBCore:Client:CallCommand',function(command,args)
+    local arguments = ""
+
+    for k, v in pairs(args) do
+        arguments = arguments ..v.." "
+    end
+
+    ExecuteCommand(command.." "..arguments)
+end)

--- a/server/events.lua
+++ b/server/events.lua
@@ -205,6 +205,8 @@ RegisterNetEvent('QBCore:CallCommand', function(command, args)
 				TriggerClientEvent('QBCore:Notify', src, 'No Access To This Command', 'error')
 			end
 		end
+	else
+		TriggerClientEvent('QBCore:Client:CallCommand',src,command,args)
 	end
 end)
 


### PR DESCRIPTION
**Describe Pull request**
If you try using this method to call any command that is non-qbcore it will do nothing -> Great example is the command binding resource, where it uses this method to call the bound command.

I have encountered more qbcore resources that use this method without the actual knowledge that this method cannot invoke non-qbcore commands.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all its functionality? Yes
- Does your code fit the style guidelines? Commit message No / Code Yes
- Does your PR fit the contribution guidelines? Yes
