### PR TITLE
Fix always "on duty" at login.

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -111,7 +111,9 @@ function QBCore.Player.CheckPlayerData(source, PlayerData)
     PlayerData.job.name = PlayerData.job.name or 'unemployed'
     PlayerData.job.label = PlayerData.job.label or 'Civilian'
     PlayerData.job.payment = PlayerData.job.payment or 10
-    PlayerData.job.onduty = PlayerData.job.onduty or true
+    if QBCore.Shared.ForceJobDefaultDutyAtLogin or PlayerData.job.onduty == nil then
+        PlayerData.job.onduty = QBCore.Shared.Jobs[PlayerData.job.name].defaultDuty
+    end
     PlayerData.job.isboss = PlayerData.job.isboss or false
     PlayerData.job.grade = PlayerData.job.grade or {}
     PlayerData.job.grade.name = PlayerData.job.grade.name or 'Freelancer'

--- a/shared.lua
+++ b/shared.lua
@@ -607,6 +607,7 @@ QBShared.Gangs = {
 }
 
 -- Jobs
+QBShared.ForceJobDefaultDutyAtLogin = true -- true: Force duty state to jobdefaultDuty | false: set duty state from database last saved
 QBShared.Jobs = {
 	['unemployed'] = {
 		label = 'Civilian',


### PR DESCRIPTION
Every time you login, it is started as "On Duty", it does not seem to be a correct behavior.
The correct operation would be that if I'm "on duty" at the time of disconnection, when I return it is "on duty" and in the same way for if I'm "off duty"

A variable has been added that forced to take the duty that indicates in "defaultDuty" element of the jobs array when it login, in this way if it disconnects while being "on duty", when login it has to go to job place and apply for "on duty" again

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **[yes]**
- Does your code fit the style guidelines? **[yes]**
- Does your PR fit the contribution guidelines? **[yes]**
