### PR TITLE
Optimize Load Inventory function

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -525,7 +525,7 @@ end
 
 QBCore.Player.LoadInventory = function(PlayerData)
     PlayerData.items = {}
-    local result = exports.oxmysql:fetchSync('SELECT * FROM players WHERE citizenid = ?', { PlayerData.citizenid })
+    local result = exports.oxmysql:fetchSync('SELECT inventory FROM players WHERE citizenid = ?', { PlayerData.citizenid })
     if result[1] then
         if result[1].inventory then
             plyInventory = json.decode(result[1].inventory)


### PR DESCRIPTION
Change from * which selects every column in the players table to just selecting the inventory column.

This should result in slightly faster loading times.

**Describe Pull request**
This PR results in a better loading time when fetching the inventory from the Players table

If your PR is to fix an issue mention that issue here
I think correctly constructed MySQL Queries are the bigger performance increases rather then avoiding the problem and switching to OxMYSQL as badly written queries will only be slightly faster.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
