### PR TITLE
refactor(maths): move maths function to shared.lua

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -1,5 +1,4 @@
 QBCore.Functions = {}
-QBCore.Functions.Math = {}
 QBCore.RequestId = 0
 
 -- Player
@@ -629,23 +628,4 @@ function QBCore.Functions.SetVehicleProperties(vehicle, props)
             SetVehicleLivery(vehicle, props.modLivery)
         end
     end
-end
-
--- Extra Math Functions
-
--- Math Rounding Credits: http://lua-users.org/wiki/SimpleRound
-function QBCore.Functions.Math.Sign(v)
-	return (v >= 0 and 1) or -1
-end
-
--- Math Rounding Credits: http://lua-users.org/wiki/SimpleRound
--- Usage:
--- QBCore.Functions.Math.Round(119.68, 0.01) = 119.68
--- QBCore.Functions.Math.Round(119.68, 0.1) = 119.7
--- QBCore.Functions.Math.Round(119.68) = 120
--- QBCore.Functions.Math.Round(119.68, 100) = 100
--- QBCore.Functions.Math.Round(119.68, 1000) = 0
-function QBCore.Functions.Math.Round(v, bracket)
-	bracket = bracket or 1
-	return QBCore.Functions.Math.Sign(v/bracket + QBCore.Functions.Math.Sign(v) * 0.5) * bracket
 end

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -1,5 +1,4 @@
 QBCore.Functions = {}
-QBCore.Functions.Math = {}
 
 -- Getters
 -- Get your player first and then trigger a function on them
@@ -299,23 +298,4 @@ function QBCore.Functions.IsLicenseInUse(license)
         end
     end
     return false
-end
-
--- Extra Math Functions
-
--- Math Rounding Credits: http://lua-users.org/wiki/SimpleRound
-function QBCore.Functions.Math.Sign(v)
-	return (v >= 0 and 1) or -1
-end
-
--- Math Rounding Credits: http://lua-users.org/wiki/SimpleRound
--- Usage:
--- QBCore.Functions.Math.Round(119.68, 0.01) = 119.68
--- QBCore.Functions.Math.Round(119.68, 0.1) = 119.7
--- QBCore.Functions.Math.Round(119.68) = 120
--- QBCore.Functions.Math.Round(119.68, 100) = 100
--- QBCore.Functions.Math.Round(119.68, 1000) = 0
-function QBCore.Functions.Math.Round(v, bracket)
-	bracket = bracket or 1
-	return QBCore.Functions.Math.Sign(v/bracket + QBCore.Functions.Math.Sign(v) * 0.5) * bracket
 end

--- a/shared.lua
+++ b/shared.lua
@@ -36,6 +36,16 @@ QBShared.SplitStr = function(str, delimiter)
     return result
 end
 
+-- Math Rounding Credits: http://lua-users.org/wiki/SimpleRound
+QBShared.Sign = function(v)
+	return (v >= 0 and 1) or -1
+end
+
+QBShared.Round = function(v, bracket)
+	bracket = bracket or 1
+	return QBShared.Sign(v/bracket + QBCore.Functions.Math.Sign(v) * 0.5) * bracket
+end
+
 QBShared.StarterItems = {
     ['phone'] = { amount = 1, item = 'phone' },
     ['id_card'] = { amount = 1, item = 'id_card' },


### PR DESCRIPTION
**Describe Pull request**
Moves QBCore.Functions.Maths to shared.lua. This is to bring them in line with the other misc shared functions for strings and numbers.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? nope, I just moved them
- Does your code fit the style guidelines? quite possibly
- Does your PR fit the contribution guidelines? most likely
