### PR TITLE
Prevent confusion with OOC

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -204,7 +204,7 @@ QBCore.Commands.Add('ooc', 'OOC Chat Message', {}, false, function(source, args)
                 TriggerClientEvent('chat:addMessage', v, {
                     color = { 0, 0, 255},
                     multiline = true,
-                    args = {'OOC | '.. GetPlayerName(src), message}
+                    args = {'Proxmity OOC | '.. GetPlayerName(src), message}
                 })
                 TriggerEvent('qb-log:server:CreateLog', 'ooc', 'OOC', 'white', '**' .. GetPlayerName(src) .. '** (CitizenID: ' .. Player.PlayerData.citizenid .. ' | ID: ' .. src .. ') **Message:** ' .. message, false)
             end


### PR DESCRIPTION
**Describe Pull request**
Changed the text for admins and gods to 'Proximity OOC' instead of 'OOC' to prevent confusing double messages if they're out of range, it will only be normal OOC if they are in range or they are sending the message

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [no] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
