### PR TITLE
Adjusted length of citizenid to 50

### DIFF
--- a/qbcore.sql
+++ b/qbcore.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS `players` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `citizenid` varchar(255) NOT NULL,
+  `citizenid` varchar(50) NOT NULL,
   `cid` int(11) DEFAULT NULL,
   `license` varchar(255) NOT NULL,
   `name` varchar(255) NOT NULL,


### PR DESCRIPTION
The qb-core schema is full of inconsistencies and missing some key RDBMS features.
Th is PR adjusts the length of the citizen id from 255 to 50 to match its length in other tables. There's no point having mismatched lengths on common fields you'd use for queries joining tables.