### PR TITLE
Add in Shared function for Trimming whitespace in plates

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -315,6 +315,11 @@ function QBCore.Functions.DeleteVehicle(vehicle)
     DeleteVehicle(vehicle)
 end
 
+function QBCore.Functions.GetPlate(vehicle)
+    if vehicle == 0 then return end
+    return Trim(GetVehicleNumberPlateText(vehicle))
+end
+
 function QBCore.Functions.GetVehicleProperties(vehicle)
     if DoesEntityExist(vehicle) then
         local colorPrimary, colorSecondary = GetVehicleColours(vehicle)


### PR DESCRIPTION
**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

This PR is the foundation for Trimming plates in all resources that reference vehicle plates, this will allow plates with less than 8 Characters to work with QB resources (mechanic and garage mainly), and not return white spaces. For example, the plate "TEST" would return "  TEST  " so when trying to put it back into the garage or add mods to it, it would fail.

For example in qb-garages: TriggerEvent("vehiclekeys:client:SetOwner", QBCore.Functions.GetPlate(veh)) would return "TEST instead of "  TEST  " when using the native.

What I did was replace GetVehicleNumberPlateText( with QBCore.Functions.GetPlate( in all resources that contain the QBCore object.

