### PR TITLE
Feat/get duty

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -77,6 +77,7 @@ function QBCore.Functions.GetQBPlayers()
     return QBCore.Players
 end
 
+--- Gets a list of all on duty players of a specified job and the number
 function QBCore.Functions.GetPlayersOnDuty(job)
     local players = {}
     local count = 0
@@ -92,6 +93,7 @@ function QBCore.Functions.GetPlayersOnDuty(job)
     return players, count
 end
 
+-- Returns only the amount of players on duty for the specified job
 function QBCore.Functions.GetDutyCount(job)
     local count = 0
 

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -76,6 +76,22 @@ end
 function QBCore.Functions.GetQBPlayers()
     return QBCore.Players
 end
+
+function QBCore.Functions.GetPlayersOnDuty(job)
+    local players = {}
+    local count = 0
+
+    for src, Player in pairs(QBCore.Players) do
+        if Player.PlayerData.job.name == job then
+            if Player.PlayerData.job.onduty then
+                players[#players + 1] = src
+                count = count + 1
+            end
+        end
+    end
+    return players, count
+end
+
 -- Paychecks (standalone - don't touch)
 
 function PaycheckLoop()

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -92,6 +92,19 @@ function QBCore.Functions.GetPlayersOnDuty(job)
     return players, count
 end
 
+function QBCore.Functions.GetDutyCount(job)
+    local count = 0
+
+    for _, Player in pairs(QBCore.Players) do
+        if Player.PlayerData.job.name == job then
+            if Player.PlayerData.job.onduty then
+                count = count + 1
+            end
+        end
+    end
+    return count
+end
+
 -- Paychecks (standalone - don't touch)
 
 function PaycheckLoop()


### PR DESCRIPTION
**Describe Pull request**

Expanding upon #278 this PR adds two new functions GetDutyCount which returns the number of players onduty with a specified job and GetPlayersOnDuty which returns both the count and a table with all of the player ids of those with the specified job.

This PR adds functionality requested in #275 

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes boss
- Does your code fit the style guidelines? absolutely
- Does your PR fit the contribution guidelines? quite possibly
