### PR TITLE
Index is incorrect when players disconnect

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -111,8 +111,7 @@ end
 
 function PaycheckLoop()
     local Players = QBCore.Functions.GetQBPlayers()
-    for i = 1, #Players, 1 do
-        local Player = Players[i]
+    for _, Player in pairs(Players) do
         local payment = Player.PlayerData.job.payment
         if Player.PlayerData.job and Player.PlayerData.job.onduty and payment > 0 then
             Player.Functions.AddMoney('bank', payment)


### PR DESCRIPTION
It causes the index count to be skewed, and in turn causes an error in the thread and it never runs again until restart. Using the pairs alleviated this in a test environment.

**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest) Tested in repro environment using a very set of specific skills.
- Does your code fit the style guidelines? [yes/no] yes?
- Does your PR fit the contribution guidelines? [yes/no] yes?
