### PR TITLE
feat(GetCoreObject): implicit restart SharedObject assignment

### DIFF
--- a/import.lua
+++ b/import.lua
@@ -1,0 +1,16 @@
+-- This file primarily is for implicit handling for restarts of `qb-core`
+-- Whenever qb-core is restarted, the shared object table containing
+-- function refs becomes invalid. To solve this, we must reassign our
+-- table again with the update function ref pointers at resource start
+
+-- Any changes to the resource name, means this handler won't work anymore
+
+QBCore = exports['qb-core']:GetCoreObject()
+
+AddEventHandler('onResourceStart', function(resName)
+    -- We only want to reassign funcref table,
+    -- when qb-core resource status changes.
+    if resName ~= 'qb-core' then return end
+    -- Lets refresh local table with updated func refs
+    QBCore = exports['qb-core']:GetCoreObject()
+end)


### PR DESCRIPTION
**Describe Pull request**
This pull request allows for a pattern of implicit `qb-core` restart handling in other resources.

As many of you are aware, if experienced with the SharedObject pattern present in ESX and now in QB, you know that upon restart of the `core` resource, each consuming resource's table of function refs becomes invalid. Leading to the dreaded `cannot index function ref` error.

tldr; Because of how function refs operate, we need to refresh each consumer resource's local SharedObject to reflect the updated one.

**Usage**
To utilize this implicit handler, we need to reference the `import.lua` script in any consuming resources prior to it's script files

```lua
-- fxmanifest.lua

shared_scripts {
  '@qb-core/import.lua'
  -- ...other resource scripts
}
```

**Resource Pattern Changes**
When using the `import.lua` file, QBCore is implicitly defined in the global scope without the need for explicit developer assignment. **This assumes that the shared object table is named QBCore**

**Notes**
If you wish to allow resources to correctly work after a restart of the `core` resource and you don't want to utilize the `import.lua` file for whatever reason (edge cases, naming shared table something other than QBCore, etc), you can manually add the restart event handler to each resource.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest) ✅ 
- Does your code fit the style guidelines? [yes/no] ✅ 
- Does your PR fit the contribution guidelines? [yes/no] ✅ 
