### PR TITLE
Updated 'setjob' command to check job validity

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -142,7 +142,11 @@ QBCore.Commands.Add('setjob', 'Set A Players Job (Admin Only)', { { name = 'id',
     local src = source
     local Player = QBCore.Functions.GetPlayer(tonumber(args[1]))
     if Player then
-        Player.Functions.SetJob(tostring(args[2]), tonumber(args[3]))
+       if QBCore.Functions.DoesJobExist(args[2], args[3]) then
+            Player.Functions.SetJob(tostring(args[2]), tonumber(args[3]))
+        else
+            TriggerClientEvent('QBCore:Notify', src, 'Invalid Job/Grade', 'error')
+        end
     else
         TriggerClientEvent('QBCore:Notify', src, 'Player Not Online', 'error')
     end

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -299,3 +299,17 @@ function QBCore.Functions.IsLicenseInUse(license)
     end
     return false
 end
+
+-- Job Check
+
+function QBCore.Functions.DoesJobExist(job, grade)
+    if job and grade then
+        for k, v in pairs(QBCore.Shared.Jobs) do
+            if job == k and v.grades[grade] then
+                return true
+            end
+        end
+    end
+    
+    return false
+end


### PR DESCRIPTION
Added a validity check to 'setjob' command that returns an error

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
