### PR TITLE
Update the way jobrep metadata is handled

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -80,12 +80,21 @@ function QBCore.Player.CheckPlayerData(source, PlayerData)
     PlayerData.metadata['craftingrep'] = PlayerData.metadata['craftingrep'] or 0
     PlayerData.metadata['attachmentcraftingrep'] = PlayerData.metadata['attachmentcraftingrep'] or 0
     PlayerData.metadata['currentapartment'] = PlayerData.metadata['currentapartment'] or nil
-    PlayerData.metadata['jobrep'] = PlayerData.metadata['jobrep'] or {
-        ['tow'] = 0,
-        ['trucker'] = 0,
-        ['taxi'] = 0,
-        ['hotdog'] = 0,
-    }
+    if PlayerData.metadata['jobrep'] ~= nil then
+		PlayerData.metadata['jobrep'] = {
+			['tow'] = PlayerData.metadata['jobrep']['tow'] or 0,
+			['trucker'] = PlayerData.metadata['jobrep']['trucker'] or 0,
+			['taxi'] = PlayerData.metadata['jobrep']['taxi'] or 0,
+			['hotdog'] = PlayerData.metadata['jobrep']['hotdog'] or 0,
+		}
+	else
+		PlayerData.metadata['jobrep'] = {
+			['tow'] = 0,
+			['trucker'] = 0,
+			['taxi'] = 0,
+			['hotdog'] = 0,
+		}
+	end
     PlayerData.metadata['callsign'] = PlayerData.metadata['callsign'] or 'NO CALLSIGN'
     PlayerData.metadata['fingerprint'] = PlayerData.metadata['fingerprint'] or QBCore.Player.CreateFingerId()
     PlayerData.metadata['walletid'] = PlayerData.metadata['walletid'] or QBCore.Player.CreateWalletId()


### PR DESCRIPTION
**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

When you add a new job, existing characters cannot get jobrep for it because the original jobrep metadata is always loaded instead. With this method, existing characters can get jobrep for new jobs.

This checks to make sure that jobrep metadata isn't nil so that new characters do not get stuck in an infinite loop, and instead creates new jobrep metadata for them.

There may be a better way to do this, but this works.



**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
I am not running the newest qb-core script, but I have tested this for new and existing characters and does work.
- Does your code fit the style guidelines? [yes/no]
yes
- Does your PR fit the contribution guidelines? [yes/no]
yes