### PR TITLE
Added support for placing items on ground if inv too full

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -352,7 +352,8 @@ function QBCore.Player.CreatePlayer(PlayerData)
                 end
             end
         else
-            TriggerClientEvent('QBCore:Notify', self.PlayerData.source, 'Your inventory is too heavy!', 'error')
+            TriggerEvent("inventory:server:spawnOnGround", self.PlayerData.source, { name = itemInfo['name'], amount = amount, info = info or '', label = itemInfo['label'], description = itemInfo['description'] or '', weight = itemInfo['weight'], type = itemInfo['type'], unique = itemInfo['unique'], useable = itemInfo['useable'], image = itemInfo['image'], shouldClose = itemInfo['shouldClose'], slot = slot, combinable = itemInfo['combinable'] }, amount)
+            TriggerClientEvent('QBCore:Notify', self.PlayerData.source, 'Your inventory is too heavy, placing item on floor!', 'error')
         end
         return false
     end


### PR DESCRIPTION
**Describe Pull request**
Issue occured if a users inventory is too heavy then the items would just not spawn, (was a major issue for things such as bank robbery. Therefore I added this to put the items on the ground if they can not go into the users inventory.

This is linked to the PR on qb-inventory: https://github.com/qbcore-framework/qb-inventory/pull/196

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes (Be honest)
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
