### PR TITLE
Fix(RemoveItem): Exploit Remove Item

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -366,7 +366,7 @@ function QBCore.Player.CreatePlayer(PlayerData)
                 self.Functions.UpdatePlayerData()
                 TriggerEvent('qb-log:server:CreateLog', 'playerinventory', 'RemoveItem', 'red', '**' .. GetPlayerName(self.PlayerData.source) .. ' (citizenid: ' .. self.PlayerData.citizenid .. ' | id: ' .. self.PlayerData.source .. ')** lost item: [slot:' .. slot .. '], itemname: ' .. self.PlayerData.items[slot].name .. ', removed amount: ' .. amount .. ', new total amount: ' .. self.PlayerData.items[slot].amount)
                 return true
-            else
+            elseif self.PlayerData.items[slot].amount == amount then
                 self.PlayerData.items[slot] = nil
                 self.Functions.UpdatePlayerData()
                 TriggerEvent('qb-log:server:CreateLog', 'playerinventory', 'RemoveItem', 'red', '**' .. GetPlayerName(self.PlayerData.source) .. ' (citizenid: ' .. self.PlayerData.citizenid .. ' | id: ' .. self.PlayerData.source .. ')** lost item: [slot:' .. slot .. '], itemname: ' .. item .. ', removed amount: ' .. amount .. ', item removed')


### PR DESCRIPTION
**Describe Pull request**
This issues fixes the possible exploit when removing an item when sending the item slot parameter before you were able to send any amount of an item and it would return as if the remove item worked just fine returning true

If your PR is to fix an issue mention that issue here
qbcore-framework/qb-inventory#200

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes, using on my server
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
