### PR TITLE
Update fr.lua

### DIFF
--- a/locale/fr.lua
+++ b/locale/fr.lua
@@ -4,18 +4,18 @@ local Translations = {
         wrong_format = 'Format incorrect',
         missing_args = 'Arguments manquant (x, y, z)',
         missing_args2 = 'Tous les arguments doivent être remplis!',
-        no_access = 'Vous n\'avez pas accès a cette commande',
-        company_too_poor = 'Votre entreprise est fauchée',
+        no_access = 'Vous n\'avez pas accès à cette commande',
+        company_too_poor = 'Votre entreprise n\'a pas suffisamment d\'argent',
         item_exist = 'L\'objet n\'existe pas',
         too_heavy = 'L\'inventaire est plein'
     },
     success = {},
     info = {
         received_paycheck = 'Vous avez reçu votre salaire de : $%{value}',
-        job_info = 'Job: %{value} | Grade: %{value2} | service: %{value3}',
+        job_info = 'Emplois: %{value} | Grade: %{value2} | Service: %{value3}',
         gang_info = 'Gang: %{value} | Grade: %{value2}',
         on_duty = 'Vous êtes désormais en service!',
-        off_duty = 'Vous êtes désormais hors-service!'
+        off_duty = 'Vous n\'êtes plus en service!'
     }
 }
 


### PR DESCRIPTION
**Describe Pull request**
i make some update of the french translation about some mistake

1. [a to à](https://grammar.collinsdictionary.com/french-easy-learning/a-de-and-en)
2. ["est fauchée" is very familiar and is bad use of it because is more about steal someone and then "be fauché" is someone was steal so he have nothing](https://www.wordreference.com/fren/faucher). So i change for "n\'a pas suffisamment d\'argent" that mean word by word "dont have enough money"
3. Job is use in french but the translation is Emplois
4. hors-service is clearly never use for that propuse. so i just add the negation on the positive sentence

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/**no**] (Be honest)
- Does your code fit the style guidelines? [**yes**/no]
- Does your PR fit the contribution guidelines? [**yes**/no]
