### PR TITLE
fix(client/functions): Return right result when with hasitem callback

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -20,12 +20,8 @@ end
 function QBCore.Functions.HasItem(item)
     local p = promise.new()
     QBCore.Functions.TriggerCallback('QBCore:HasItem', function(result)
-        if result then
-            p:resolve(true)
-        end
-        p:resolve(false)
+        p:resolve(result)
     end, item)
-
     return Citizen.Await(p)
 end
 


### PR DESCRIPTION
**Describe Pull request**
This fixes the HasItem function always returning false

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
