### PR TITLE
Fix the connecting stuck "We are checking if you are banned."

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -391,9 +391,9 @@ function QBCore.Functions.IsPlayerBanned(source)
         if os.time() < result.expire then
             retval = true
             local timeTable = os.date('*t', tonumber(result.expire))
-            message = 'You have been banned from the server:\n' .. result[1].reason .. '\nYour ban expires ' .. timeTable.day .. '/' .. timeTable.month .. '/' .. timeTable.year .. ' ' .. timeTable.hour .. ':' .. timeTable.min .. '\n'
+            message = 'You have been banned from the server:\n' .. result.reason .. '\nYour ban expires ' .. timeTable.day .. '/' .. timeTable.month .. '/' .. timeTable.year .. ' ' .. timeTable.hour .. ':' .. timeTable.min .. '\n'
         else
-            MySQL.Async.execute('DELETE FROM bans WHERE id = ?', { result[1].id })
+            MySQL.Async.execute('DELETE FROM bans WHERE id = ?', { result.id })
         end
     end
     return retval, message


### PR DESCRIPTION
When a banned player tries to join the server, he will be stuck in connecting with this message "Hello ____, We are checking if you are banned."
Since the result from MySQL is a single fetch and there is not an array to index.

**Describe Pull request**
If a player got banned from the server and tried to rejoin, he will be stuck in the connection with this message "Hello ____, We are checking if you are banned."

**If your PR is to fix an issue mention that issue here**
Fixed it by replacing `result[1].reason` to `result.reason` (line 394) and `result[1].id` to `result.id` (line 396) in [server/functions.lua](https://github.com/qbcore-framework/qb-core/blob/main/server/functions.lua)

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest): yes, tried it on a new fresh server downloaded from the txAdmin recipe
- Does your code fit the style guidelines? [yes/no] yes
- Does your PR fit the contribution guidelines? [yes/no] yes
