### PR TITLE
Removed owned by deleted player houses

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -533,6 +533,7 @@ function QBCore.Player.DeleteCharacter(source, citizenid)
 			queries[i] = {query = query:format(v.table), values = { citizenid }}
 		end
 
+        MySQL.Async.execute('UPDATE houselocations JOIN player_houses ON name = house SET owned = 0 WHERE citizenid = ?', { citizenid })
         MySQL.Async.transaction(queries, function(result)
 			if result then
 				TriggerEvent('qb-log:server:CreateLog', 'joinleave', 'Character Deleted', 'red', '**' .. GetPlayerName(src) .. '** ' .. license .. ' deleted **' .. citizenid .. '**..')


### PR DESCRIPTION
Thanks to this query, when a character is eliminated it will change all columns owned from 1 to 0 of his ex houses in possession.

**KNOWN BUG**
If someone deletes the character, the row (s) on the database side are updated, but on the client side the owner of the house is not updated but there is a need to restart the fivem client.
I ask for the help of the developer community to be able to ensure that the status of the client-side houses is updated dynamically, without having to restart the fivem client.