### PR TITLE
feat(qb-core/player): Added server-side event onJobUpdate

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -196,6 +196,7 @@ function QBCore.Player.CreatePlayer(PlayerData)
             end
 
             self.Functions.UpdatePlayerData()
+            TriggerEvent('QBCore:Server:OnJobUpdate', self.PlayerData.source, self.PlayerData.job)
             TriggerClientEvent('QBCore:Client:OnJobUpdate', self.PlayerData.source, self.PlayerData.job)
             return true
         end


### PR DESCRIPTION
Added server-side event onJobUpdate so scripts can listen on server scripts if any player has changed their job. It's safer than redirecting client event to server again (never trust the client).

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
