### PR TITLE
Prevent duplicated phone and account numbers

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -56,9 +56,9 @@ function QBCore.Player.CheckPlayerData(source, PlayerData)
     PlayerData.charinfo.birthdate = PlayerData.charinfo.birthdate or '00-00-0000'
     PlayerData.charinfo.gender = PlayerData.charinfo.gender or 0
     PlayerData.charinfo.backstory = PlayerData.charinfo.backstory or 'placeholder backstory'
-    PlayerData.charinfo.nationality = PlayerData.charinfo.nationality or 'American'
-    PlayerData.charinfo.phone = PlayerData.charinfo.phone ~= nil and PlayerData.charinfo.phone or QBCore.Functions.CreatePhoneNumber()
-    PlayerData.charinfo.account = PlayerData.charinfo.account ~= nil and PlayerData.charinfo.account or QBCore.Functions.CreateAccountNumber()
+    PlayerData.charinfo.nationality = PlayerData.charinfo.nationality or 'USA'
+    PlayerData.charinfo.phone = PlayerData.charinfo.phone ~= nil and PlayerData.charinfo.phone or '1' .. math.random(111111111, 999999999)
+    PlayerData.charinfo.account = PlayerData.charinfo.account ~= nil and PlayerData.charinfo.account or 'US0' .. math.random(1, 9) .. 'QBCore' .. math.random(1111, 9999) .. math.random(1111, 9999) .. math.random(11, 99)
     -- Metadata
     PlayerData.metadata = PlayerData.metadata or {}
     PlayerData.metadata['hunger'] = PlayerData.metadata['hunger'] or 100
@@ -510,6 +510,7 @@ local playertables = { -- Add tables as needed
     { table = 'crypto_transactions' },
     { table = 'phone_invoices' },
     { table = 'phone_messages' },
+    { table = 'playerskins' },
     { table = 'player_boats' },
     { table = 'player_contacts' },
     { table = 'player_houses' },
@@ -649,34 +650,6 @@ function QBCore.Player.CreateCitizenId()
         end
     end
     return CitizenId
-end
-
-function QBCore.Functions.CreateAccountNumber()
-    local UniqueFound = false
-    local AccountNumber = nil
-    while not UniqueFound do
-        AccountNumber = 'US0' .. math.random(1, 9) .. 'QBCore' .. math.random(1111, 9999) .. math.random(1111, 9999) .. math.random(11, 99)
-        local query = '%' .. AccountNumber .. '%'
-        local result = MySQL.Sync.prepare('SELECT COUNT(*) as count FROM players WHERE metadata LIKE ?', { query })
-        if result == 0 then
-            UniqueFound = true
-        end
-    end
-    return AccountNumber
-end
-
-function QBCore.Functions.CreatePhoneNumber()
-    local UniqueFound = false
-    local PhoneNumber = nil
-    while not UniqueFound do
-        PhoneNumber = math.random(100,999) .. math.random(1000000,9999999)
-        local query = '%' .. PhoneNumber .. '%'
-        local result = MySQL.Sync.prepare('SELECT COUNT(*) as count FROM players WHERE metadata LIKE ?', { query })
-        if result == 0 then
-            UniqueFound = true
-        end
-    end
-    return PhoneNumber
 end
 
 function QBCore.Player.CreateFingerId()

--- a/server/player.lua
+++ b/server/player.lua
@@ -658,7 +658,7 @@ function QBCore.Functions.CreateAccountNumber()
     while not UniqueFound do
         AccountNumber = 'US0' .. math.random(1, 9) .. 'QBCore' .. math.random(1111, 9999) .. math.random(1111, 9999) .. math.random(11, 99)
         local query = '%' .. AccountNumber .. '%'
-        local result = MySQL.Sync.prepare('SELECT COUNT(*) as count FROM players WHERE metadata LIKE ?', { query })
+        local result = MySQL.Sync.prepare('SELECT COUNT(*) as count FROM players WHERE charinfo LIKE ?', { query })
         if result == 0 then
             UniqueFound = true
         end
@@ -672,7 +672,7 @@ function QBCore.Functions.CreatePhoneNumber()
     while not UniqueFound do
         PhoneNumber = math.random(100,999) .. math.random(1000000,9999999)
         local query = '%' .. PhoneNumber .. '%'
-        local result = MySQL.Sync.prepare('SELECT COUNT(*) as count FROM players WHERE metadata LIKE ?', { query })
+        local result = MySQL.Sync.prepare('SELECT COUNT(*) as count FROM players WHERE charinfo LIKE ?', { query })
         if result == 0 then
             UniqueFound = true
         end

--- a/server/player.lua
+++ b/server/player.lua
@@ -56,9 +56,9 @@ function QBCore.Player.CheckPlayerData(source, PlayerData)
     PlayerData.charinfo.birthdate = PlayerData.charinfo.birthdate or '00-00-0000'
     PlayerData.charinfo.gender = PlayerData.charinfo.gender or 0
     PlayerData.charinfo.backstory = PlayerData.charinfo.backstory or 'placeholder backstory'
-    PlayerData.charinfo.nationality = PlayerData.charinfo.nationality or 'USA'
-    PlayerData.charinfo.phone = PlayerData.charinfo.phone ~= nil and PlayerData.charinfo.phone or '1' .. math.random(111111111, 999999999)
-    PlayerData.charinfo.account = PlayerData.charinfo.account ~= nil and PlayerData.charinfo.account or 'US0' .. math.random(1, 9) .. 'QBCore' .. math.random(1111, 9999) .. math.random(1111, 9999) .. math.random(11, 99)
+    PlayerData.charinfo.nationality = PlayerData.charinfo.nationality or 'American'
+    PlayerData.charinfo.phone = PlayerData.charinfo.phone ~= nil and PlayerData.charinfo.phone or QBCore.Functions.CreatePhoneNumber()
+    PlayerData.charinfo.account = PlayerData.charinfo.account ~= nil and PlayerData.charinfo.account or QBCore.Functions.CreateAccountNumber()
     -- Metadata
     PlayerData.metadata = PlayerData.metadata or {}
     PlayerData.metadata['hunger'] = PlayerData.metadata['hunger'] or 100
@@ -510,7 +510,6 @@ local playertables = { -- Add tables as needed
     { table = 'crypto_transactions' },
     { table = 'phone_invoices' },
     { table = 'phone_messages' },
-    { table = 'playerskins' },
     { table = 'player_boats' },
     { table = 'player_contacts' },
     { table = 'player_houses' },
@@ -650,6 +649,34 @@ function QBCore.Player.CreateCitizenId()
         end
     end
     return CitizenId
+end
+
+function QBCore.Functions.CreateAccountNumber()
+    local UniqueFound = false
+    local AccountNumber = nil
+    while not UniqueFound do
+        AccountNumber = 'US0' .. math.random(1, 9) .. 'QBCore' .. math.random(1111, 9999) .. math.random(1111, 9999) .. math.random(11, 99)
+        local query = '%' .. AccountNumber .. '%'
+        local result = MySQL.Sync.prepare('SELECT COUNT(*) as count FROM players WHERE metadata LIKE ?', { query })
+        if result == 0 then
+            UniqueFound = true
+        end
+    end
+    return AccountNumber
+end
+
+function QBCore.Functions.CreatePhoneNumber()
+    local UniqueFound = false
+    local PhoneNumber = nil
+    while not UniqueFound do
+        PhoneNumber = math.random(100,999) .. math.random(1000000,9999999)
+        local query = '%' .. PhoneNumber .. '%'
+        local result = MySQL.Sync.prepare('SELECT COUNT(*) as count FROM players WHERE metadata LIKE ?', { query })
+        if result == 0 then
+            UniqueFound = true
+        end
+    end
+    return PhoneNumber
 end
 
 function QBCore.Player.CreateFingerId()

--- a/server/player.lua
+++ b/server/player.lua
@@ -57,8 +57,8 @@ function QBCore.Player.CheckPlayerData(source, PlayerData)
     PlayerData.charinfo.gender = PlayerData.charinfo.gender or 0
     PlayerData.charinfo.backstory = PlayerData.charinfo.backstory or 'placeholder backstory'
     PlayerData.charinfo.nationality = PlayerData.charinfo.nationality or 'USA'
-    PlayerData.charinfo.phone = PlayerData.charinfo.phone ~= nil and PlayerData.charinfo.phone or '1' .. math.random(111111111, 999999999)
-    PlayerData.charinfo.account = PlayerData.charinfo.account ~= nil and PlayerData.charinfo.account or 'US0' .. math.random(1, 9) .. 'QBCore' .. math.random(1111, 9999) .. math.random(1111, 9999) .. math.random(11, 99)
+    PlayerData.charinfo.phone = PlayerData.charinfo.phone ~= nil and PlayerData.charinfo.phone or QBCore.Functions.CreatePhoneNumber()
+    PlayerData.charinfo.account = PlayerData.charinfo.account ~= nil and PlayerData.charinfo.account or QBCore.Functions.CreateAccountNumber()
     -- Metadata
     PlayerData.metadata = PlayerData.metadata or {}
     PlayerData.metadata['hunger'] = PlayerData.metadata['hunger'] or 100
@@ -650,6 +650,34 @@ function QBCore.Player.CreateCitizenId()
         end
     end
     return CitizenId
+end
+
+function QBCore.Functions.CreateAccountNumber()
+    local UniqueFound = false
+    local AccountNumber = nil
+    while not UniqueFound do
+        AccountNumber = 'US0' .. math.random(1, 9) .. 'QBCore' .. math.random(1111, 9999) .. math.random(1111, 9999) .. math.random(11, 99)
+        local query = '%' .. AccountNumber .. '%'
+        local result = MySQL.Sync.prepare('SELECT COUNT(*) as count FROM players WHERE metadata LIKE ?', { query })
+        if result == 0 then
+            UniqueFound = true
+        end
+    end
+    return AccountNumber
+end
+
+function QBCore.Functions.CreatePhoneNumber()
+    local UniqueFound = false
+    local PhoneNumber = nil
+    while not UniqueFound do
+        PhoneNumber = math.random(100,999) .. math.random(1000000,9999999)
+        local query = '%' .. PhoneNumber .. '%'
+        local result = MySQL.Sync.prepare('SELECT COUNT(*) as count FROM players WHERE metadata LIKE ?', { query })
+        if result == 0 then
+            UniqueFound = true
+        end
+    end
+    return PhoneNumber
 end
 
 function QBCore.Player.CreateFingerId()


### PR DESCRIPTION
**Describe Pull request**
This will prevent the chance of duplicated phone and account numbers, although the chance is very low it's still a possibility as I have experienced this myself and this will resolve that issue. I feel like this should be implemented as these are meant to be unique for each player.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
