### PR TITLE
Trigger Job Update on Duty Update

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -233,6 +233,7 @@ function QBCore.Player.CreatePlayer(PlayerData)
     self.Functions.SetJobDuty = function(onDuty)
         self.PlayerData.job.onduty = onDuty
         self.Functions.UpdatePlayerData()
+        TriggerClientEvent('QBCore:Client:OnJobUpdate', self.PlayerData.source, self.PlayerData.job)
     end
 
     self.Functions.SetMetaData = function(meta, val)


### PR DESCRIPTION
**Describe Pull request**
This commit adds `QBCore:Client:OnJobUpdate` to SetJobDuty. Whenever someone toggles/changes their duty it will be sent to all scripts using this event. Previously resources would have to fetch the player data to check if their duty changes. 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] Yes:
In order for this to work with qb-policejob you need to change the OnJobUpdate within the resource.
Before:
```
RegisterNetEvent('QBCore:Client:OnJobUpdate', function(JobInfo)
    PlayerJob = JobInfo
    TriggerServerEvent("police:server:UpdateBlips")
    if JobInfo.name == "lspd" or JobInfo.name == "bcso" or JobInfo.name == "sasp" then
        if PlayerJob.onduty then
            TriggerServerEvent("QBCore:ToggleDuty")
            onDuty = false
        end
    end

    if (PlayerJob ~= nil) and PlayerJob.name ~= "lspd" or PlayerJob.name ~= "bcso" or PlayerJob.name ~= "sasp" then
        if DutyBlips then
            for k, v in pairs(DutyBlips) do
                RemoveBlip(v)
            end
        end
        DutyBlips = {}
    end
end)
```

After:
```
RegisterNetEvent('QBCore:Client:OnJobUpdate', function(JobInfo)
    PlayerJob = JobInfo
    TriggerServerEvent("police:server:UpdateBlips")
    onDuty = PlayerJob.onduty

    if (PlayerJob ~= nil) and PlayerJob.name ~= "lspd" or PlayerJob.name ~= "bcso" or PlayerJob.name ~= "sasp" then
        if DutyBlips then
            for k, v in pairs(DutyBlips) do
                RemoveBlip(v)
            end
        end
        DutyBlips = {}
    end
end)
```

- Does your code fit the style guidelines? [yes/no] Yes
- Does your PR fit the contribution guidelines? [yes/no] Yes
