### PR TITLE
feat(functions): add play animation function

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -85,6 +85,15 @@ function QBCore.Functions.RequestAnimDict(animDict)
 	end
 end
 
+function QBCore.Functions.PlayAnim(animDict, animName, upperbodyOnly, duration)
+    local flags = upperbodyOnly == true and 16 or 0
+    local runTime = duration ~= nil and duration or -1
+
+    QBCore.Functions.RequestAnimDict(animDict)
+    TaskPlayAnim(PlayerPedId(), animDict, animName, 8.0, 1.0, runTime, flags, 0.0, false, false, true)
+    RemoveAnimDict(animDict)
+end
+
 function QBCore.Functions.LoadModel(ModelName)
 	RequestModel(ModelName)
 	while not HasModelLoaded(ModelName) do


### PR DESCRIPTION
Credits to Molicheu#2053 from QBCore Discord.

**Describe Pull request**
This PR adds a function for playing animations on the ped. It comes with some customization, such as the animation dict and name, if it should only play on upper body or not and the duration.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
