### PR TITLE
feat (shared): Added modular shared tables

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -140,3 +140,16 @@ RegisterNetEvent('QBCore:Command:ShowMe3D', function(senderId, msg)
         end
     end)
 end)
+
+-- Listen to Shared being updated
+RegisterNetEvent('QBCore:Client:OnSharedUpdate', function(tableName, key, value)
+    QBCore.Shared[tableName][key] = value
+    TriggerEvent('QBCore:Client:UpdateObject')
+end)
+
+RegisterNetEvent('QBCore:Client:OnSharedUpdateMultiple', function(tableName, values)
+    for key, value in ipairs(values) do
+        QBCore.Shared[tableName][key] = value
+    end
+    TriggerEvent('QBCore:Client:UpdateObject')
+end)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -30,6 +30,7 @@ server_scripts {
 	'server/player.lua',
 	'server/events.lua',
 	'server/commands.lua',
+	'server/exports.lua',
 	'server/debug.lua'
 }
 

--- a/server/exports.lua
+++ b/server/exports.lua
@@ -1,25 +1,17 @@
 -- Single add job function which should only be used if you planning on adding a single job
-local function AddJob(jobName, job, source)
+local function AddJob(jobName, job)
     if type(jobName) ~= "string" then
-        print('Failed to add the item, name is not a string')
-        if source ~= nil and source ~= '' then
-            TriggerClientEvent('QBCore:Notify', source, 'Failed to add the job, name is not a string', 'error', 3000)
-        end
-        return false
+        return false, "invalid_job_name"
     end
 
     if QBCore.Shared.Jobs[jobName] ~= nil then
-        print('Failed to add the item, item already exists')
-        if source ~= nil and source ~= '' then
-            TriggerClientEvent('QBCore:Notify', source, 'Failed to add the job, job already exists', 'error', 3000)
-        end
-        return false
+        return false, "job_exists"
     end
 
     QBCore.Shared.Jobs[jobName] = job
     TriggerClientEvent('QBCore:Client:OnSharedUpdate', -1,'Jobs', jobName, job)
     TriggerEvent('QBCore:Server:UpdateObject')
-    return true
+    return true, "success"
 end
 QBCore.Functions.AddJob = AddJob
 exports('AddJob', AddJob)
@@ -27,52 +19,47 @@ exports('AddJob', AddJob)
 -- Multiple Add Jobs
 local function AddJobs(jobs)
     local shouldContinue = true
+    local message = "success"
+    local errorItem = nil
     for key, value in pairs(jobs) do
         if type(key) ~= "string" then
-            print('Failed to add the job, name is not a string')
+            message = 'invalid_job_name'
             shouldContinue = false
-            goto continue
+            errorItem = jobs[key]
+            break
         end
 
         if QBCore.Shared.Jobs[key] ~= nil then
-            print('Failed to add the job, job already exists: ' .. key)
+            message = 'job_exists'
             shouldContinue = false
-            goto continue
+            errorItem = jobs[key]
+            break
         end
 
         QBCore.Shared.Jobs[key] = value
-        ::continue::
     end
 
-    if not shouldContinue then return false end
+    if not shouldContinue then return false, message, errorItem end
     TriggerClientEvent('QBCore:Client:OnSharedUpdateMultiple', -1, 'Jobs', jobs)
     TriggerEvent('QBCore:Server:UpdateObject')
-    return true
+    return true, message, nil
 end
 QBCore.Functions.AddJobs = AddJobs
 exports('AddJobs', AddJobs)
 
 -- Single add item
-local function AddItem(itemName, item, source)
+local function AddItem(itemName, item)
     if type(itemName) ~= "string" then
-        print('Failed to add the item, name is not a string')
-        if source ~= nil and source ~= '' then
-            TriggerClientEvent('QBCore:Notify', source, 'Failed to add the item, name is not a string', 'error', 3000)
-        end
-        return false
+        return false, "invalid_item_name"
     end
     if QBCore.Shared.Items[itemName] ~= nil then
-        print('Failed to add the item, item already exists')
-        if source ~= nil and source ~= '' then
-            TriggerClientEvent('QBCore:Notify', source, 'Failed to add the item, item already exists', 'error', 3000)
-        end
-        return false
+        return false, "item_exists"
     end
 
     QBCore.Shared.Items[itemName] = item
     TriggerClientEvent('QBCore:Client:OnSharedUpdate', -1, 'Items', itemName, item)
     TriggerEvent('QBCore:Server:UpdateObject')
-    return true
+    return true, "success"
 end
 QBCore.Functions.AddItem = AddItem
 exports('AddItem', AddItem)
@@ -80,26 +67,30 @@ exports('AddItem', AddItem)
 -- Multiple Add Items
 local function AddItems(items)
     local shouldContinue = true
+    local message = "success"
+    local errorItem = nil
     for key, value in pairs(items) do
         if type(key) ~= "string" then
-            print('Failed to add the item, name is not a string')
+            message = "invalid_item_name"
             shouldContinue = false
-            goto continue
+            errorItem = items[key]
+            break
         end
 
         if QBCore.Shared.Items[key] ~= nil then
-            print('Failed to add the item, item already exists: ' .. key)
+            message = "item_exists"
             shouldContinue = false
-            goto continue
+            errorItem = items[key]
+            break
         end
 
         QBCore.Shared.Items[key] = value
-        ::continue::
     end
-    if not shouldContinue then return false end
+
+    if not shouldContinue then return false, message, errorItem end
     TriggerClientEvent('QBCore:Client:OnSharedUpdateMultiple', -1, 'Items', items)
     TriggerEvent('QBCore:Server:UpdateObject')
-    return true
+    return true, message, nil
 end
 QBCore.Functions.AddItems = AddItems
 exports('AddItems', AddItems)
@@ -107,24 +98,16 @@ exports('AddItems', AddItems)
 -- Single Add Gang
 local function AddGang(gangName, gang, source)
     if type(gangName) ~= "string" then
-        print('Failed to add the gang, name is not a string')
-        if source ~= nil and source ~= '' then
-            TriggerClientEvent('QBCore:Notify', source, 'Failed to add the gang, name is not a string', 'error', 3000)
-        end
-        return false
+        return false, "invalid_gang_name"
     end
     if QBCore.Shared.Gangs[gangName] ~= nil then
-        print('Failed to add the gang, gang already exists')
-        if source ~= nil and source ~= '' then
-            TriggerClientEvent('QBCore:Notify', source, 'Failed to add the gang, gang already exists', 'error', 3000)
-        end
-        return false
+        return false, "gang_exists"
     end
 
     QBCore.Shared.Gangs[gangName] = gang
     TriggerClientEvent('QBCore:Client:OnSharedUpdate', -1,'Gangs', gangName, gang)
     TriggerEvent('QBCore:Server:UpdateObject')
-    return true
+    return true, "success"
 end
 QBCore.Functions.AddGang = AddGang
 exports('AddGang', AddGang)
@@ -132,28 +115,30 @@ exports('AddGang', AddGang)
 -- Multiple Add Gangs
 local function AddGangs(gangs)
     local shouldContinue = true
-
+    local message = "success"
+    local errorItem = nil
+    
     for key, value in pairs(gangs) do
         if type(key) ~= "string" then
-            print('Failed to add the gang, name is not a string')
+            message = "invalid_gang_name"
             shouldContinue = false
-            goto continue
+            errorItem = items[key]
+            break
         end
 
         if QBCore.Shared.Gangs[key] ~= nil then
-            print('Failed to add the gang, gang already exists: ' .. key)
+            message = "gang_exists"
             shouldContinue = false
-            goto continue
+            errorItem = items[key]
+            break
         end
-
         QBCore.Shared.Gangs[key] = value
-        ::continue::
     end
 
-    if not shouldContinue then return false end
+    if not shouldContinue then return false, message, errorItem end
     TriggerClientEvent('QBCore:Client:OnSharedUpdateMultiple', -1, 'Gangs', gangs)
     TriggerEvent('QBCore:Server:UpdateObject')
-    return true
+    return true, message, nil
 end
 QBCore.Functions.AddGangs = AddGangs
 exports('AddGangs', AddGangs)

--- a/server/exports.lua
+++ b/server/exports.lua
@@ -1,0 +1,62 @@
+-- Single add job function which should only be used if you planning on adding a single job
+local function AddJob(jobName, job)
+    QBCore.Shared.Jobs[jobName] = job
+    TriggerClientEvent('QBCore:Client:OnSharedUpdate', -1,'Jobs', jobName, job)
+    TriggerEvent('QBCore:Server:UpdateObject')
+end
+QBCore.Functions.AddJob = AddJob
+exports('AddJob', AddJob)
+
+-- Multiple Add Jobs
+local function AddJobs(jobs)
+    for key, value in pairs(jobs) do
+        QBCore.Shared.Jobs[key] = value
+    end
+
+    TriggerClientEvent('QBCore:Client:OnSharedUpdateMultiple', -1, 'Jobs', jobs)
+    TriggerEvent('QBCore:Server:UpdateObject')
+end
+QBCore.Functions.AddJobs = AddJobs
+exports('AddJobs', AddJobs)
+
+-- Single add item
+local function AddItem(itemName, item)
+    QBCore.Shared.Items[itemName] = item
+    TriggerClientEvent('QBCore:Client:OnSharedUpdate', -1, 'Items', itemName, item)
+    TriggerEvent('QBCore:Server:UpdateObject')
+end
+QBCore.Functions.AddItem = AddItem
+exports('AddItem', AddItem)
+
+-- Multiple Add Items
+local function AddItems(items)
+    for key, value in pairs(items) do
+        QBCore.Shared.Items[key] = value
+    end
+
+    TriggerClientEvent('QBCore:Client:OnSharedUpdateMultiple', -1, 'Items', items)
+    TriggerEvent('QBCore:Server:UpdateObject')
+end
+QBCore.Functions.AddItems = AddItems
+exports('AddItems', AddItems)
+
+-- Single Add Gang
+local function AddGang(gangName, gang)
+    QBCore.Shared.Gangs[gangName] = gang
+    TriggerClientEvent('QBCore:Client:OnSharedUpdate', -1,'Gangs', gangName, gang)
+    TriggerEvent('QBCore:Server:UpdateObject')
+end
+QBCore.Functions.AddGang = AddGang
+exports('AddGang', AddGang)
+
+-- Multiple Add Gangs
+local function AddGangs(gangs)
+    for key, value in pairs(gangs) do
+        QBCore.Shared.Gangs[key] = value
+    end
+
+    TriggerClientEvent('QBCore:Client:OnSharedUpdateMultiple', -1, 'Gangs', gangs)
+    TriggerEvent('QBCore:Server:UpdateObject')
+end
+QBCore.Functions.AddGangs = AddGangs
+exports('AddGangs', AddGangs)

--- a/server/exports.lua
+++ b/server/exports.lua
@@ -1,62 +1,159 @@
 -- Single add job function which should only be used if you planning on adding a single job
-local function AddJob(jobName, job)
+local function AddJob(jobName, job, source)
+    if type(jobName) ~= "string" then
+        print('Failed to add the item, name is not a string')
+        if source ~= nil and source ~= '' then
+            TriggerClientEvent('QBCore:Notify', source, 'Failed to add the job, name is not a string', 'error', 3000)
+        end
+        return false
+    end
+
+    if QBCore.Shared.Jobs[jobName] ~= nil then
+        print('Failed to add the item, item already exists')
+        if source ~= nil and source ~= '' then
+            TriggerClientEvent('QBCore:Notify', source, 'Failed to add the job, job already exists', 'error', 3000)
+        end
+        return false
+    end
+
     QBCore.Shared.Jobs[jobName] = job
     TriggerClientEvent('QBCore:Client:OnSharedUpdate', -1,'Jobs', jobName, job)
     TriggerEvent('QBCore:Server:UpdateObject')
+    return true
 end
 QBCore.Functions.AddJob = AddJob
 exports('AddJob', AddJob)
 
 -- Multiple Add Jobs
 local function AddJobs(jobs)
+    local shouldContinue = true
     for key, value in pairs(jobs) do
+        if type(key) ~= "string" then
+            print('Failed to add the job, name is not a string')
+            shouldContinue = false
+            goto continue
+        end
+
+        if QBCore.Shared.Jobs[key] ~= nil then
+            print('Failed to add the job, job already exists: ' .. key)
+            shouldContinue = false
+            goto continue
+        end
+
         QBCore.Shared.Jobs[key] = value
+        ::continue::
     end
 
+    if not shouldContinue then return false end
     TriggerClientEvent('QBCore:Client:OnSharedUpdateMultiple', -1, 'Jobs', jobs)
     TriggerEvent('QBCore:Server:UpdateObject')
+    return true
 end
 QBCore.Functions.AddJobs = AddJobs
 exports('AddJobs', AddJobs)
 
 -- Single add item
-local function AddItem(itemName, item)
+local function AddItem(itemName, item, source)
+    if type(itemName) ~= "string" then
+        print('Failed to add the item, name is not a string')
+        if source ~= nil and source ~= '' then
+            TriggerClientEvent('QBCore:Notify', source, 'Failed to add the item, name is not a string', 'error', 3000)
+        end
+        return false
+    end
+    if QBCore.Shared.Items[itemName] ~= nil then
+        print('Failed to add the item, item already exists')
+        if source ~= nil and source ~= '' then
+            TriggerClientEvent('QBCore:Notify', source, 'Failed to add the item, item already exists', 'error', 3000)
+        end
+        return false
+    end
+
     QBCore.Shared.Items[itemName] = item
     TriggerClientEvent('QBCore:Client:OnSharedUpdate', -1, 'Items', itemName, item)
     TriggerEvent('QBCore:Server:UpdateObject')
+    return true
 end
 QBCore.Functions.AddItem = AddItem
 exports('AddItem', AddItem)
 
 -- Multiple Add Items
 local function AddItems(items)
+    local shouldContinue = true
     for key, value in pairs(items) do
-        QBCore.Shared.Items[key] = value
-    end
+        if type(key) ~= "string" then
+            print('Failed to add the item, name is not a string')
+            shouldContinue = false
+            goto continue
+        end
 
+        if QBCore.Shared.Items[key] ~= nil then
+            print('Failed to add the item, item already exists: ' .. key)
+            shouldContinue = false
+            goto continue
+        end
+
+        QBCore.Shared.Items[key] = value
+        ::continue::
+    end
+    if not shouldContinue then return false end
     TriggerClientEvent('QBCore:Client:OnSharedUpdateMultiple', -1, 'Items', items)
     TriggerEvent('QBCore:Server:UpdateObject')
+    return true
 end
 QBCore.Functions.AddItems = AddItems
 exports('AddItems', AddItems)
 
 -- Single Add Gang
-local function AddGang(gangName, gang)
+local function AddGang(gangName, gang, source)
+    if type(gangName) ~= "string" then
+        print('Failed to add the gang, name is not a string')
+        if source ~= nil and source ~= '' then
+            TriggerClientEvent('QBCore:Notify', source, 'Failed to add the gang, name is not a string', 'error', 3000)
+        end
+        return false
+    end
+    if QBCore.Shared.Gangs[gangName] ~= nil then
+        print('Failed to add the gang, gang already exists')
+        if source ~= nil and source ~= '' then
+            TriggerClientEvent('QBCore:Notify', source, 'Failed to add the gang, gang already exists', 'error', 3000)
+        end
+        return false
+    end
+
     QBCore.Shared.Gangs[gangName] = gang
     TriggerClientEvent('QBCore:Client:OnSharedUpdate', -1,'Gangs', gangName, gang)
     TriggerEvent('QBCore:Server:UpdateObject')
+    return true
 end
 QBCore.Functions.AddGang = AddGang
 exports('AddGang', AddGang)
 
 -- Multiple Add Gangs
 local function AddGangs(gangs)
+    local shouldContinue = true
+
     for key, value in pairs(gangs) do
+        if type(key) ~= "string" then
+            print('Failed to add the gang, name is not a string')
+            shouldContinue = false
+            goto continue
+        end
+
+        if QBCore.Shared.Gangs[key] ~= nil then
+            print('Failed to add the gang, gang already exists: ' .. key)
+            shouldContinue = false
+            goto continue
+        end
+
         QBCore.Shared.Gangs[key] = value
+        ::continue::
     end
 
+    if not shouldContinue then return false end
     TriggerClientEvent('QBCore:Client:OnSharedUpdateMultiple', -1, 'Gangs', gangs)
     TriggerEvent('QBCore:Server:UpdateObject')
+    return true
 end
 QBCore.Functions.AddGangs = AddGangs
 exports('AddGangs', AddGangs)

--- a/server/player.lua
+++ b/server/player.lua
@@ -549,6 +549,8 @@ end
 QBCore.Player.LoadInventory = function(PlayerData)
     PlayerData.items = {}
     local inventory = MySQL.Sync.prepare('SELECT inventory FROM players WHERE citizenid = ?', { PlayerData.citizenid })
+    local missingItems = {}
+
     if inventory then
         inventory = json.decode(inventory)
         if next(inventory) then
@@ -571,10 +573,17 @@ QBCore.Player.LoadInventory = function(PlayerData)
                             slot = item.slot,
                             combinable = itemInfo['combinable']
                         }
+                    else
+                        missingItems[#missingItems+1] = item.name:lower()
                     end
+
                 end
             end
         end
+    end
+
+    if #missingItems > 0 then
+        print(("%s the following items removed as they no longer exist: %s"):format(GetPlayerName(PlayerData.source), json.encode(missingItems)))
     end
     return PlayerData
 end


### PR DESCRIPTION
I've added the ability to dynamically add new items, jobs, and gangs to the shared without having to edit the shared files.

I've added the following functions: 
|Function or Event | Scope | Description | returns |
|--|--|--|--|
| exports['qb-core']:AddItem(itemName, item) |  Server | Accepts an item name and item object - will add new entry to QBCore.Shared.Items. | boolean, string |
| exports['qb-core']:AddJob(jobName, job) |  Server | Accepts an job name and job object - will add new entry to QBCore.Shared.Jobs.| boolean, string |
| exports['qb-core']:AddGang(gangName, gang) |  Server | Accepts an gang name and gang object - will add new entry to QBCore.Shared.Gangs.| boolean, string |
| exports['qb-core']:AddItems(items) |  Server | Accepts a table or array - will loop through the table and add new entries to QBCore.Shared.Items | boolean, string, errorItem |
| exports['qb-core']:AddJobs(jobs) |  Server | Accepts a table or array - will loop through the table and add new entries to QBCore.Shared.Jobs | boolean, string, errorItem |
| exports['qb-core']:AddGangs(gangs) |  Server | Accepts a table or array - will loop through the table and add new entries to QBCore.Shared.Gangs | boolean, string, errorItem |
| QBCore.Functions.AddItem(itemName, item) |  Server | Accepts an item name and item object - will add new entry to QBCore.Shared.Items | boolean, string |
| QBCore.Functions.AddJob(jobName, Job) |  Server | Accepts an job name and job object - will add new entry to QBCore.Shared.Jobs | boolean, string |
| QBCore.Functions.AddGang(gangName, gang) |  Server | Accepts an gang name and gang object - will add new entry to QBCore.Shared.Gangs | boolean, string |
| QBCore.Functions.AddItems(items) |  Server | Accepts a table or array - will loop through the table and add new entries to QBCore.Shared.Items | boolean, string, errorItem |
| QBCore.Functions.AddJobs(jobs) |  Server | Accepts a table or array - will loop through the table and add new entries to QBCore.Shared.Jobs | boolean, string, errorItem |
| QBCore.Functions.AddGangs(gangs) |  Server | Accepts a table or array - will loop through the table and add new entries to QBCore.Shared.Gangs| boolean, string, errorItem |
| TriggerServerEvent('QBCore:Sever:UpdateObject') | Server | Accepts nothing - used to update the core object (PLEASE USE THE BELOW EXAMPLE) | none |
| TriggerClientEvent('QBCore:Client:UpdateObject') | Client | Accepts nothing - used to update the core object (PLEASE USE THE BELOW EXAMPLE) | none |

How to use the new server event, you'll need this if you handle items within your resource(s)
```lua
RegisterNetEvent('QBCore:Server:UpdateObject', function()
        if source ~= '' then return false end -- Safety check if the event was not called from the server.
	QBCore = exports['qb-core']:GetCoreObject()
end)
```
How to use the new client even, you'll need this if you handle items within your resource(s)
```lua
RegisterNetEvent('QBCore:Server:UpdateObject', function()
             if source ~= '' then return false end
	QBCore = exports['qb-core']:GetCoreObject()
end)
```

You can use these how you like, these will not save to the files so you'll need to load it everytime your resource starts.