### PR TITLE
Corrects SetModelAsNoLongerNeeded()

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -61,7 +61,7 @@ RegisterNetEvent('QBCore:Command:SpawnVehicle', function(vehName)
     end
     local vehicle = CreateVehicle(hash, GetEntityCoords(ped), GetEntityHeading(ped), true, false)
     TaskWarpPedIntoVehicle(ped, vehicle, -1)
-    SetModelAsNoLongerNeeded(vehicle)
+    SetModelAsNoLongerNeeded(hash)
     TriggerEvent("vehiclekeys:client:SetOwner", QBCore.Functions.GetPlate(vehicle))
 end)
 


### PR DESCRIPTION
**Describe Pull request**
Fixes the model being left in memory by correcting the call to native "SetModelAsNoLongerNeeded()", which was passing the vehicle entity as the argument instead of the vehicle's model (hash).

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
