### PR TITLE
Prevent people using /me to troll

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -240,6 +240,10 @@ QBCore.Commands.Add('me', 'Show local message', {{name = 'message', help = 'Mess
     local pCoords = GetEntityCoords(ped)
     local msg = table.concat(args, ' ')
     if msg == '' then return end
+    if string.match(msg, "<") then
+        TriggerClientEvent('QBCore:Notify', source, Lang:t('error.wrong_format'), 'error')
+        return 
+    end
     for k,v in pairs(QBCore.Functions.GetPlayers()) do
         local target = GetPlayerPed(v)
         local tCoords = GetEntityCoords(target)


### PR DESCRIPTION
**Describe Pull request**
This prevents people using that /me troll with the huge font size and different colors.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
