### PR TITLE
feat: add global switch function to qb-core

### DIFF
--- a/shared/main.lua
+++ b/shared/main.lua
@@ -70,6 +70,13 @@ function QBShared.SetDefaultVehicleExtras(vehicle, config)
     end
 end
 
+_G.switch = function(param, case_table)
+    local case = case_table[param]
+    if case then return case() end
+    local def = case_table['default']
+    return def and def() or nil
+end
+
 QBShared.StarterItems = {
     ['phone'] = { amount = 1, item = 'phone' },
     ['id_card'] = { amount = 1, item = 'id_card' },


### PR DESCRIPTION
Instead of nesting if/else or having to compare multiple values to the same variable it would be awesome if lua had the switch/case statement. 

By default it hasn't so i thought it might be a good addition to the core.


usage:
local a =1 (or however you want to set your argument to the switch)

switch(a, { 
    [1] = function()    -- for case 1
        print "Case 1."
    end,
    [2] = function()    -- for case 2
        print "Case 2."
    end,
    [3] = function()    -- for case 3
        print "Case 3."
    end
   ['default'] = function() --for default
        print "Default"
   end
})