### PR TITLE
:bug: Remove compound assignment operator

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -578,7 +578,7 @@ function QBCore.Player.GetTotalWeight(items)
     local weight = 0
     if not items then return 0 end
     for _, item in pairs(items) do
-        weight += item.weight * item.amount
+        weight = weight + (item.weight * item.amount)
     end
     return tonumber(weight)
 end


### PR DESCRIPTION
**Describe Pull request**
Compound assignment operators are not valid in Lua 5.4 without applying a patch (http://lua-users.org/wiki/LuaPowerPatches). This will convert this calculation back to the original method which should not throw any errors on usage.

![image](https://user-images.githubusercontent.com/58707473/161128015-4da5d905-9ca5-4651-a995-09da3b1576c3.png)
![image](https://user-images.githubusercontent.com/58707473/161128059-00ab86b0-d51c-4650-80a9-1974717a1c9c.png)

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] No - but have tested the math and function in a standard Lua 5.4.4 environment.
- Does your code fit the style guidelines? [yes/no] yes
- Does your PR fit the contribution guidelines? [yes/no] yes
