### PR TITLE
feat: Implement QBCore.Shared.VehicleHashs

### DIFF
--- a/shared/vehicles.lua
+++ b/shared/vehicles.lua
@@ -1,4 +1,6 @@
 QBShared = QBShared or {}
+QBShared.VehicleHashs = {}
+
 QBShared.Vehicles = {
 	--- Compacts
 	['asbo'] = {
@@ -4418,3 +4420,7 @@ QBShared.Vehicles = {
 		['shop'] = 'air',
 	},
 }
+
+for k,v in pairs(QBShared.Vehicles) do
+	QBShared.VehicleHashs[v.hash] = v
+end

--- a/shared/vehicles.lua
+++ b/shared/vehicles.lua
@@ -1,5 +1,5 @@
 QBShared = QBShared or {}
-QBShared.VehicleHashs = {}
+QBShared.VehicleHashes = {}
 
 QBShared.Vehicles = {
 	--- Compacts
@@ -4422,5 +4422,5 @@ QBShared.Vehicles = {
 }
 
 for k,v in pairs(QBShared.Vehicles) do
-	QBShared.VehicleHashs[v.hash] = v
+	QBShared.VehicleHashes[v.hash] = v
 end


### PR DESCRIPTION

**Describe Pull request**
Indexs the vehicles jenkins joaat(Hash) value as the key of the table as the key so we dont have to do some shitty ass loop through the vehicles comparing joaat values. I have no clue why this secondary table was removed in the first place if I had to guess people were lazy but this should help the lazys by automatically filling the table.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
Yes

- Does your code fit the style guidelines? [yes/no]
Yes

- Does your PR fit the contribution guidelines? [yes/no]
Yes
