### PR TITLE
Add support for commas and integers in the TP command

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -65,9 +65,9 @@ QBCore.Commands.Add('tp', 'TP To Player or Coords (Admin Only)', { { name = 'id/
         end
     else
         if args[1] and args[2] and args[3] then
-            local x = tonumber(args[1])
-            local y = tonumber(args[2])
-            local z = tonumber(args[3])
+            local x = tonumber((args[1]:gsub(",",""))) + .0
+            local y = tonumber((args[2]:gsub(",",""))) + .0
+            local z = tonumber((args[3]:gsub(",",""))) + .0
             if x ~= 0 and y ~= 0 and z ~= 0 then
                 TriggerClientEvent('QBCore:Command:TeleportToCoords', source, x, y, z)
             else


### PR DESCRIPTION
**Describe Pull request**
Adds support for commas and integers in the **`/tp`** command.
Admins can now copy coordinates from **`vector3`** and **`vector4`** vectors without having to edit their input, as well as the ability to use integer values as inputs.

The current format will be expanded from,
**`0.0 0.0 0.0`**
to also include the following formats,
**`0 0 0`**
**`0, 0, 0,`**
**`0.0, 0.0, 0.0,`**

**Questions:**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **Yes**
- Does your code fit the style guidelines? **Yes**
- Does your PR fit the contribution guidelines? **Yes**