### PR TITLE
Updates to the /me command

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -256,8 +256,7 @@ QBCore.Commands.Add('me', 'Show local message', {{name = 'message', help = 'Mess
     if #args < 1 then TriggerClientEvent('QBCore:Notify', source, Lang:t('error.missing_args2'), 'error') return end
     local ped = GetPlayerPed(source)
     local pCoords = GetEntityCoords(ped)
-    local msg = table.concat(args, ' ')
-    if string.match(msg, "<") then TriggerClientEvent('QBCore:Notify', source, Lang:t('error.wrong_format'), 'error') return end
+    local msg = table.concat(args, ' '):gsub('[~<].-[>~]', '')
     local Players = QBCore.Functions.GetPlayers()
     for i=1, #Players do
         local Player = Players[i]

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -258,11 +258,13 @@ QBCore.Commands.Add('me', 'Show local message', {{name = 'message', help = 'Mess
     local pCoords = GetEntityCoords(ped)
     local msg = table.concat(args, ' ')
     if string.match(msg, "<") then TriggerClientEvent('QBCore:Notify', source, Lang:t('error.wrong_format'), 'error') return end
-    for k,v in pairs(QBCore.Functions.GetPlayers()) do
-        local target = GetPlayerPed(v)
+    local Players = QBCore.Functions.GetPlayers()
+    for i=1, #Players do
+        local Player = Players[i]
+        local target = GetPlayerPed(Player)
         local tCoords = GetEntityCoords(target)
-        if #(pCoords - tCoords) < 20 then
-            TriggerClientEvent('QBCore:Command:ShowMe3D', v, source, msg)
+        if target == ped or #(pCoords - tCoords) < 20 then
+            TriggerClientEvent('QBCore:Command:ShowMe3D', Player, source, msg)
         end
     end
 end, 'user')

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -253,10 +253,10 @@ end, 'user')
 -- Me command
 
 QBCore.Commands.Add('me', 'Show local message', {{name = 'message', help = 'Message to respond with'}}, false, function(source, args)
+    if #args < 1 then TriggerClientEvent('QBCore:Notify', source, Lang:t('error.missing_args2'), 'error') return end
     local ped = GetPlayerPed(source)
     local pCoords = GetEntityCoords(ped)
     local msg = table.concat(args, ' ')
-    if msg == '' then return end
     if string.match(msg, "<") then TriggerClientEvent('QBCore:Notify', source, Lang:t('error.wrong_format'), 'error') return end
     for k,v in pairs(QBCore.Functions.GetPlayers()) do
         local target = GetPlayerPed(v)


### PR DESCRIPTION
**Describe Pull request**
Updates to the `/me` command

- Moved input length check to be first to avoid unnecessarily running natives.
- Converted pairs() loop to for-loop as recommended in [Lua performance test #9](https://springrts.com/wiki/Lua_Performance#TEST_9:_for-loops)
- Reworked the original implementation of pull request #571
   - Now uses pattern replacing to remove substrings matching `[~<].-[>~]`
      - [Regular expression variant with examples](https://regex101.com/r/rrNMnx/1)
      -  The pattern covers all text formatting methods described on the [Font and Colors](https://wiki.rage.mp/index.php?title=Fonts_and_Colors) page on the RAGE Multiplayer Wiki.
 <details>
<summary>Pattern Replacing Tests</summary>
<table>
<tr>
	<td>Input from user
	<td>Output to "ShowMe3D" event
<tr>
	<td>&lt;font size='1000'&gt;red text
	<td>red text
<tr>
	<td>red text&lt;font size='1000'&gt;
	<td>red text
<tr>
	<td>This is &lt;font size='1000'&gt;red text
	<td>This is red text
<tr>
	<td>This is &lt;font size='1000'&gt;red &lt;font color='#FFFFFF'&gt;text
	<td>This is red text
<tr>
	<td>This is ~r~red text
	<td>This is red text
<tr>
	<td>This is ~r~red ~w~text
	<td>This is red text
<tr>
	<td>This is ~HUD_COLOUR_RED~red text
	<td>This is red text
<tr>
	<td>This is ~HUD_COLOUR_RED~red ~HUD_COLOUR_WHITE~text
	<td>This is red text
<tr>
	<td>&lt;font size='1000'&gt; TROLL MESSAGE
	<td>&nbsp;TROLL MESSAGE
</table>
</details>

---
**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **Yes**
- Does your code fit the style guidelines? **Yes**
- Does your PR fit the contribution guidelines? **Yes**
