### PR TITLE
[FIX] Neon Colours not working correctly

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -685,10 +685,9 @@ function QBCore.Functions.SetVehicleProperties(vehicle, props)
             end
         end
         if props.neonEnabled then
-            SetVehicleNeonLightEnabled(vehicle, 0, props.neonEnabled[1])
-            SetVehicleNeonLightEnabled(vehicle, 1, props.neonEnabled[2])
-            SetVehicleNeonLightEnabled(vehicle, 2, props.neonEnabled[3])
-            SetVehicleNeonLightEnabled(vehicle, 3, props.neonEnabled[4])
+            for neonIndex, enableNeons in pairs(props.neonEnabled) do
+                SetVehicleNeonLightEnabled(vehicle, tonumber(neonIndex), enableNeons)
+            end
         end
         if props.neonColor then
             SetVehicleNeonLightsColour(vehicle, props.neonColor[1], props.neonColor[2], props.neonColor[3])


### PR DESCRIPTION
Currently, the Neon colours are referring to indexes that assume that the vehicle mod property`neonEnabled` is an array. Instead, due to the way the the JSON properties are encoding their children, we are reading and writing objects.
Where we currently attempt to set the vehicle's neon enabled status by using the following excerpt of code found in `client/functions.lua:688`
```
SetVehicleNeonLightEnabled(vehicle, 0, props.neonEnabled[1])
SetVehicleNeonLightEnabled(vehicle, 1, props.neonEnabled[2])
SetVehicleNeonLightEnabled(vehicle, 2, props.neonEnabled[3])
SetVehicleNeonLightEnabled(vehicle, 3, props.neonEnabled[4])
``` 

We should be refering to the **STRING** index with a 0 base (0 to 3) like so:
```
SetVehicleNeonLightEnabled(vehicle, 0, props.neonEnabled["0"])
SetVehicleNeonLightEnabled(vehicle, 1, props.neonEnabled["1"])
SetVehicleNeonLightEnabled(vehicle, 2, props.neonEnabled["2"])
SetVehicleNeonLightEnabled(vehicle, 3, props.neonEnabled["3"])
```

However, this is still not safe as this assumes a complete object containing all 4 indexes.
The method in the previous versions of QB Core function `function QBCore.Functions.SetVehicleProperties` was far safer. The previous version used a `for loop` to iterate over the object pairs and then only make changes to what was available. This allows us to allow users to be a bit more careless and avoid potential problems in the future where we only have portions of the `neonEnabled` object available.

In short, this PR involved me reverting to a previous version of QB Core where an iteration was taking place, and converting the index to a number.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
