### PR TITLE
Add ability to use QBCore:CallCommand to call non-qb commands

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -181,6 +181,20 @@ RegisterNetEvent('QBCore:Client:UseItem', function(item)
     TriggerServerEvent('QBCore:Server:UseItem', item)
 end)
 
+RegisterNetEvent('QBCore:Client:CallCommand',function(command,args)
+    if not command then return end
+
+    local arguments = ""
+
+    if args then
+        for k, v in pairs(args) do
+            arguments = arguments ..v.." "
+        end
+    end
+
+    ExecuteCommand(command.." "..arguments)
+end)
+
 -- Me command
 
 local function Draw3DText(coords, str)

--- a/server/events.lua
+++ b/server/events.lua
@@ -186,7 +186,10 @@ end)
 
 RegisterNetEvent('QBCore:CallCommand', function(command, args)
     local src = source
-    if not QBCore.Commands.List[command] then return end
+    if not QBCore.Commands.List[command] then
+        TriggerClientEvent('QBCore:Client:CallCommand',src,command,args) 
+        return 
+    end
     local Player = QBCore.Functions.GetPlayer(src)
     if not Player then return end
     local hasPerm = QBCore.Functions.HasPermission(src, "command."..QBCore.Commands.List[command].name)


### PR DESCRIPTION
**Describe Pull request**
Added ability to use `QBCore:CallCommand` event to call non-qb commands. This is useful for resources like qb-commandbinding.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all its functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
