### PR TITLE
Fixed wrong type SetVehicleProperties / SetVehicleDoorBroken

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -662,7 +662,7 @@ function QBCore.Functions.SetVehicleProperties(vehicle, props)
         if props.doorStatus then
             for doorIndex, breakDoor in pairs(props.doorStatus) do
                 if breakDoor then
-                    SetVehicleDoorBroken(vehicle, doorIndex, true)
+                    SetVehicleDoorBroken(vehicle, tonumber(doorIndex), true)
                 end
             end
         end


### PR DESCRIPTION
This fixes an error that occurs when trying to apply vehicle properties. 

- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? YES
- Does your code fit the style guidelines? YES
- Does your PR fit the contribution guidelines? YES
