### PR TITLE
Fixed GetVehicleProperties livery

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -463,7 +463,7 @@ function QBCore.Functions.GetVehicleProperties(vehicle)
         end
 
         local modLivery = GetVehicleMod(vehicle, 48)
-        if GetVehicleMod(vehicle, 48) == -1 and GetVehicleLivery(vehicle) ~= 0 then
+        if GetVehicleMod(vehicle, 48) == -1 then
             modLivery = GetVehicleLivery(vehicle)
         end
 


### PR DESCRIPTION
Livery was not set when GetVehicleLivery(vehicle) == 0

- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? YES
- Does your code fit the style guidelines? YES
- Does your PR fit the contribution guidelines? YES
