### PR TITLE
Fix object amount parameter for hasitem function

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -26,7 +26,7 @@ function QBCore.Functions.HasItem(items, amount)
         if isTable then
             for k, v in pairs(items) do
                 local itemKV = {k, v}
-                if itemData and itemData.name == itemKV[kvIndex] and ((not amount and not isArray and itemData.amount >= v) or (isArray and amount and itemData.amount >= amount) or (not amount and isArray)) then
+                if itemData and itemData.name == itemKV[kvIndex] and ((amount and itemData.amount >= amount) or (not isArray and itemData.amount >= v) or (not amount and isArray)) then
                     count += 1
                 end
             end

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -387,7 +387,7 @@ function QBCore.Functions.HasItem(source, items, amount)
         for k, v in pairs(items) do
             local itemKV = {k, v}
             local item = Player.Functions.GetItemByName(itemKV[kvIndex])
-            if item and ((not amount and not isArray and item.amount >= v) or (isArray and amount and item.amount >= amount) or (not amount and isArray)) then
+            if item and ((amount and item.amount >= amount) or (not isArray and item.amount >= v) or (not amount and isArray)) then
                 count += 1
             end
         end


### PR DESCRIPTION
**Describe Pull request**
`QBCore.Functions.HasItem({['item1'] = 1, ['item2'] = 2}, 1 -- [[ The issue was happening with this last parameter ]])`
This fixes the issue of using the above code and getting the wrong result when having the items

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
