### PR TITLE
feat(server/commands): multiple permission support and fix argsrequired

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -13,17 +13,43 @@ end)
 
 -- Register & Refresh Commands
 
-function QBCore.Commands.Add(name, help, arguments, argsrequired, callback, permission)
+function QBCore.Commands.Add(name, help, arguments, argsrequired, callback, permission, ...)
     local restricted = true -- Default to restricted for all commands
     if not permission then permission = 'user' end -- some commands don't pass permission level
     if permission == 'user' then restricted = false end -- allow all users to use command
-    RegisterCommand(name, callback, restricted) -- Register command within fivem
-    if not QBCore.Commands.IgnoreList[permission] then -- only create aces for extra perm levels
-        ExecuteCommand(('add_ace qbcore.%s command.%s allow'):format(permission, name))
+
+    RegisterCommand(name, function(source, args, rawCommand) -- Register command within fivem
+        if argsrequired and #args < #arguments then
+            return TriggerClientEvent('chat:addMessage', source, {
+                color = {255, 0, 0},
+                multiline = true,
+                args = {"System", Lang:t("error.missing_args2")}
+            })
+        end
+        callback(source, args, rawCommand)
+    end, restricted)
+
+    local extraPerms = ... and table.pack(...) or nil
+    if extraPerms then
+        extraPerms[extraPerms.n + 1] = permission -- The `n` field is the number of arguments in the packed table
+        extraPerms.n += 1
+        permission = extraPerms
+        for i = 1, permission.n do
+            if not QBCore.Commands.IgnoreList[permission[i]] then -- only create aces for extra perm levels
+                ExecuteCommand(('add_ace qbcore.%s command.%s allow'):format(permission[i], name))
+            end
+        end
+        permission.n = nil
+    else
+        permission = tostring(permission:lower())
+        if not QBCore.Commands.IgnoreList[permission] then -- only create aces for extra perm levels
+            ExecuteCommand(('add_ace qbcore.%s command.%s allow'):format(permission, name))
+        end
     end
+
     QBCore.Commands.List[name:lower()] = {
         name = name:lower(),
-        permission = tostring(permission:lower()),
+        permission = permission,
         help = help,
         arguments = arguments,
         argsrequired = argsrequired,


### PR DESCRIPTION
**Describe Pull request**
This fixes the issue of the argsrequired field not doing anymore
This also adds support for more than one permission, the following format is the only one accepted for multiple permissions
```lua
QBCore.Commands.Add("test", "test", {}, false, function()
    print('something does it')
end, 'perm1', 'perm2', 'perm3', 'and', 'add', 'as', 'much', 'as', 'you', 'want') -- This is the format, just seperate the strings by a comma and each string will be seen as a different permission to add the ace permission to, you can add as many as you want, no need for tables :)
```

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
