### PR TITLE
Fix HasItem check if amount is provided and item not found

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -34,7 +34,7 @@ function QBCore.Functions.HasItem(items, amount)
                 return true
             end
         else -- Single item as string
-            if itemData and itemData.name == items and (not amount or (amount and itemData.amount >= amount)) then
+            if itemData and itemData.name == items and (not amount or (itemData and amount and itemData.amount >= amount)) then
                 return true
             end
         end

--- a/server/events.lua
+++ b/server/events.lua
@@ -238,7 +238,7 @@ QBCore.Functions.CreateCallback('QBCore:HasItem', function(source, cb, items, am
 		end
 	else -- Single item as string
 		local item = Player.Functions.GetItemByName(items)
-        if item and not amount or (amount and item.amount >= amount) then
+        if item and not amount or (item and amount and item.amount >= amount) then
             retval = true
         end
 	end


### PR DESCRIPTION
This PR fixes an issue where if you provide single item name and amount, and if item wasn't found, it'll still try to index item and throw error on server side.

Reproduction (client side):
```lua
 QBCore.Functions.TriggerCallback('QBCore:HasItem', function(hasItem)
            print(hasItem)
end, "anyitem", 1)
```

Error which will be thrown:
![image](https://user-images.githubusercontent.com/55489629/176744160-abc76776-1e6b-4b4d-892f-f74a76f3d3bd.png)

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
