### PR TITLE
update player.lua - To fix number check

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -82,7 +82,7 @@ function QBCore.Player.CheckPlayerData(source, PlayerData)
     PlayerData.charinfo.gender = PlayerData.charinfo.gender or 0
     PlayerData.charinfo.backstory = PlayerData.charinfo.backstory or 'placeholder backstory'
     PlayerData.charinfo.nationality = PlayerData.charinfo.nationality or 'USA'
-    PlayerData.charinfo.phone = PlayerData.charinfo.phone or QBCore.Functions.CreatePhoneNumber()
+    PlayerData.charinfo.phone = tostring(PlayerData.charinfo.phone) or QBCore.Functions.CreatePhoneNumber()
     PlayerData.charinfo.account = PlayerData.charinfo.account or QBCore.Functions.CreateAccountNumber()
     -- Metadata
     PlayerData.metadata = PlayerData.metadata or {}


### PR DESCRIPTION
**Describe Pull request**
Fixes some players' phone numbers not matching in the "GetPlayerByPhone" function
Tests are also tested on qb-phone and gksphone. and the problem was found as a solution.
This is because in previous updates Phone number was set as number.


**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
