### PR TITLE
Move usableitems back to the core

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -1,6 +1,7 @@
 QBCore.Functions = {}
 QBCore.Player_Buckets = {}
 QBCore.Entity_Buckets = {}
+QBCore.UsableItems = {}
 
 -- Getters
 -- Get your player first and then trigger a function on them
@@ -251,40 +252,18 @@ end
 
 -- Items
 
-function QBCore.Functions.CreateUseableItem(item, cb)
-    if GetResourceState('qb-inventory') == 'missing' then return end
-
-    if GetResourceState('qb-inventory') ~= 'started' then
-        CreateThread(function()
-            repeat
-                Wait(1000)
-            until GetResourceState('qb-inventory') == 'started'
-            exports['qb-inventory']:CreateUsableItem(item, cb)
-        end)
-    else
-        exports['qb-inventory']:CreateUsableItem(item, cb)
-    end
+function QBCore.Functions.CreateUseableItem(item, data)
+    QBCore.UsableItems[item] = data
 end
 
 function QBCore.Functions.CanUseItem(item)
-    if GetResourceState('qb-inventory') == 'missing' then return end
-    return exports['qb-inventory']:GetUsableItem(item)
+    return QBCore.UsableItems[item]
 end
 
 function QBCore.Functions.UseItem(source, item)
     if GetResourceState('qb-inventory') == 'missing' then return end
     exports['qb-inventory']:UseItem(source, item)
 end
-
-exports('SetUseableItems', function(val)
-    QBCore.UseableItems = val
-end)
-
-exports('SetUseableItem', function(item, cb)
-    QBCore.UseableItems[item] = cb
-end)
-
-exports('GetUseableItems', function() return QBCore.UseableItems end)
 
 -- Kick Player
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -3,7 +3,6 @@ QBCore.Config = QBConfig
 QBCore.Shared = QBShared
 QBCore.ClientCallbacks = {}
 QBCore.ServerCallbacks = {}
-QBCore.UseableItems = {}
 
 exports('GetCoreObject', function()
     return QBCore


### PR DESCRIPTION
**Describe Pull request**
This fixes the issue of usableitems not being saved in qb-inventory after restarting it, the core can't be restarted (it can but everything would break then so you'd be forced to restart the server) so we don't have to worry about keeping the data

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
