### PR TITLE
removed unnecessary key

### DIFF
--- a/shared/vehicles.lua
+++ b/shared/vehicles.lua
@@ -10,7 +10,6 @@ QBShared.Vehicles = {
 		['price'] = 4000,
 		['category'] = 'compacts',
 		['hash'] = `asbo`,
-		['shop'] = 'pdm',
 	},
 	['blista'] = {
 		['name'] = 'Blista',
@@ -19,7 +18,6 @@ QBShared.Vehicles = {
 		['price'] = 13000,
 		['category'] = 'compacts',
 		['hash'] = `blista`,
-		['shop'] = 'pdm',
 	},
 	['brioso'] = {
 		['name'] = 'Brioso R/A',
@@ -28,7 +26,6 @@ QBShared.Vehicles = {
 		['price'] = 20000,
 		['category'] = 'compacts',
 		['hash'] = `brioso`,
-		['shop'] = 'pdm',
 	},
 	['club'] = {
 		['name'] = 'Club',
@@ -37,7 +34,6 @@ QBShared.Vehicles = {
 		['price'] = 8000,
 		['category'] = 'compacts',
 		['hash'] = `club`,
-		['shop'] = 'pdm',
 	},
 	['dilettante'] = {
 		['name'] = 'Dilettante',
@@ -46,7 +42,6 @@ QBShared.Vehicles = {
 		['price'] = 9000,
 		['category'] = 'compacts',
 		['hash'] = `dilettante`,
-		['shop'] = 'pdm',
 	},
 	['dilettante2'] = {
 		['name'] = 'Dilettante Patrol',
@@ -55,7 +50,6 @@ QBShared.Vehicles = {
 		['price'] = 12000,
 		['category'] = 'compacts',
 		['hash'] = `dilettante2`,
-		['shop'] = 'pdm',
 	},
 	['kanjo'] = {
 		['name'] = 'Blista Kanjo',
@@ -64,7 +58,6 @@ QBShared.Vehicles = {
 		['price'] = 12000,
 		['category'] = 'compacts',
 		['hash'] = `kanjo`,
-		['shop'] = 'pdm',
 	},
 	['issi2'] = {
 		['name'] = 'Issi',
@@ -73,7 +66,6 @@ QBShared.Vehicles = {
 		['price'] = 7000,
 		['category'] = 'compacts',
 		['hash'] = `issi2`,
-		['shop'] = 'pdm',
 	},
 	['issi3'] = {
 		['name'] = 'Issi Classic',
@@ -82,7 +74,6 @@ QBShared.Vehicles = {
 		['price'] = 5000,
 		['category'] = 'compacts',
 		['hash'] = `issi3`,
-		['shop'] = 'pdm',
 	},
 	['issi4'] = {							--DLC
 		['name'] = 'Issi Arena',
@@ -91,7 +82,6 @@ QBShared.Vehicles = {
 		['price'] = 80000,
 		['category'] = 'compacts',
 		['hash'] = `issi4`,
-		['shop'] = 'pdm',
 	},
 	['issi5'] = {							--DLC
 		['name'] = 'Issi Arena',
@@ -100,7 +90,6 @@ QBShared.Vehicles = {
 		['price'] = 80000,
 		['category'] = 'compacts',
 		['hash'] = `issi5`,
-		['shop'] = 'pdm',
 	},
 	['issi6'] = {							--DLC
 		['name'] = 'Issi Arena',
@@ -109,7 +98,6 @@ QBShared.Vehicles = {
 		['price'] = 80000,
 		['category'] = 'compacts',
 		['hash'] = `issi6`,
-		['shop'] = 'pdm',
 	},
 	['panto'] = {
 		['name'] = 'Panto',
@@ -118,7 +106,6 @@ QBShared.Vehicles = {
 		['price'] = 3200,
 		['category'] = 'compacts',
 		['hash'] = `panto`,
-		['shop'] = 'pdm',
 	},
 	['prairie'] = {
 		['name'] = 'Prairie',
@@ -127,7 +114,6 @@ QBShared.Vehicles = {
 		['price'] = 30000,
 		['category'] = 'compacts',
 		['hash'] = `prairie`,
-		['shop'] = 'pdm',
 	},
 	['rhapsody'] = {
 		['name'] = 'Rhapsody',
@@ -136,7 +122,6 @@ QBShared.Vehicles = {
 		['price'] = 10000,
 		['category'] = 'compacts',
 		['hash'] = `rhapsody`,
-		['shop'] = 'pdm',
 	},
 	['brioso2'] = {
 		['name'] = 'Brioso 300',
@@ -145,7 +130,6 @@ QBShared.Vehicles = {
 		['price'] = 12000,
 		['category'] = 'compacts',
 		['hash'] = `brioso2`,
-		['shop'] = 'pdm',
 	},
 	['weevil'] = {
 		['name'] = 'Weevil',
@@ -154,7 +138,6 @@ QBShared.Vehicles = {
 		['price'] = 9000,
 		['category'] = 'compacts',
 		['hash'] = `weevil`,
-		['shop'] = 'pdm',
 	},
 	--- Coupes
 	['cogcabrio'] = {
@@ -164,7 +147,6 @@ QBShared.Vehicles = {
 		['price'] = 30000,
 		['category'] = 'coupes',
 		['hash'] = `cogcabrio`,
-		['shop'] = 'pdm',
 	},
 	['exemplar'] = {
 		['name'] = 'Exemplar',
@@ -173,7 +155,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'coupes',
 		['hash'] = `exemplar`,
-		['shop'] = 'pdm',
 	},
 	['f620'] = {
 		['name'] = 'F620',
@@ -182,7 +163,6 @@ QBShared.Vehicles = {
 		['price'] = 32500,
 		['category'] = 'coupes',
 		['hash'] = `f620`,
-		['shop'] = 'pdm',
 	},
 	['felon'] = {
 		['name'] = 'Felon',
@@ -191,7 +171,6 @@ QBShared.Vehicles = {
 		['price'] = 31000,
 		['category'] = 'coupes',
 		['hash'] = `felon`,
-		['shop'] = 'pdm',
 	},
 	['felon2'] = {
 		['name'] = 'Felon GT',
@@ -200,7 +179,6 @@ QBShared.Vehicles = {
 		['price'] = 37000,
 		['category'] = 'coupes',
 		['hash'] = `felon2`,
-		['shop'] = 'pdm',
 	},
 	['jackal'] = {
 		['name'] = 'Jackal',
@@ -209,7 +187,6 @@ QBShared.Vehicles = {
 		['price'] = 19000,
 		['category'] = 'coupes',
 		['hash'] = `jackal`,
-		['shop'] = 'pdm',
 	},
 	['oracle'] = {
 		['name'] = 'Oracle',
@@ -218,7 +195,6 @@ QBShared.Vehicles = {
 		['price'] = 22000,
 		['category'] = 'sedans',
 		['hash'] = `oracle`,
-		['shop'] = 'pdm',
 	},
 	['oracle2'] = {
 		['name'] = 'Oracle XS',
@@ -227,7 +203,6 @@ QBShared.Vehicles = {
 		['price'] = 28000,
 		['category'] = 'coupes',
 		['hash'] = `oracle2`,
-		['shop'] = 'pdm',
 	},
 	['sentinel'] = {
 		['name'] = 'Sentinel',
@@ -236,7 +211,6 @@ QBShared.Vehicles = {
 		['price'] = 30000,
 		['category'] = 'coupes',
 		['hash'] = `sentinel`,
-		['shop'] = 'pdm',
 	},
 	['sentinel2'] = {
 		['name'] = 'Sentinel XS',
@@ -245,7 +219,6 @@ QBShared.Vehicles = {
 		['price'] = 33000,
 		['category'] = 'coupes',
 		['hash'] = `sentinel2`,
-		['shop'] = 'pdm',
 	},
 	['windsor'] = {
 		['name'] = 'Windsor',
@@ -254,7 +227,6 @@ QBShared.Vehicles = {
 		['price'] = 27000,
 		['category'] = 'coupes',
 		['hash'] = `windsor`,
-		['shop'] = 'pdm',
 	},
 	['windsor2'] = {
 		['name'] = 'Windsor Drop',
@@ -263,7 +235,6 @@ QBShared.Vehicles = {
 		['price'] = 34000,
 		['category'] = 'coupes',
 		['hash'] = `windsor2`,
-		['shop'] = 'pdm',
 	},
 	['zion'] = {
 		['name'] = 'Zion',
@@ -272,7 +243,6 @@ QBShared.Vehicles = {
 		['price'] = 22000,
 		['category'] = 'coupes',
 		['hash'] = `zion`,
-		['shop'] = 'pdm',
 	},
 	['zion2'] = {
 		['name'] = 'Zion Cabrio',
@@ -281,7 +251,6 @@ QBShared.Vehicles = {
 		['price'] = 28000,
 		['category'] = 'coupes',
 		['hash'] = `zion2`,
-		['shop'] = 'pdm',
 	},
 	['previon'] = {			--DLC +set sv_enforceGameBuild 2372
 		['name'] = 'Previon',
@@ -290,7 +259,6 @@ QBShared.Vehicles = {
 		['price'] = 149000,
 		['category'] = 'coupes',
 		['hash'] = `previon`,
-		['shop'] = 'pdm',
 	},
 	['champion'] = {		--DLC +set sv_enforceGameBuild 2545
 		['name'] = 'Champion',
@@ -299,7 +267,6 @@ QBShared.Vehicles = {
 		['price'] = 205000,
 		['category'] = 'coupes',
 		['hash'] = `champion`,
-		['shop'] = 'pdm',
 	},
 	['ignus'] = { 	 	--DLC +set sv_enforceGameBuild 2545
 		['name'] = 'Ignus',
@@ -308,7 +275,6 @@ QBShared.Vehicles = {
 		['price'] = 1120000,
 		['category'] = 'coupes',
 		['hash'] = `ignus`,
-		['shop'] = 'pdm',
 	},
 	['zeno'] = { 	 	--DLC +set sv_enforceGameBuild 2545
 		['name'] = 'Zeno',
@@ -317,7 +283,6 @@ QBShared.Vehicles = {
 		['price'] = 1350000,
 		['category'] = 'coupes',
 		['hash'] = `zeno`,
-		['shop'] = 'pdm',
 	},
 	--- Cycles
 	['bmx'] = {
@@ -327,7 +292,6 @@ QBShared.Vehicles = {
 		['price'] = 160,
 		['category'] = 'cycles',
 		['hash'] = `bmx`,
-		['shop'] = 'pdm',
 	},
 	['cruiser'] = {
 		['name'] = 'Cruiser',
@@ -336,7 +300,6 @@ QBShared.Vehicles = {
 		['price'] = 510,
 		['category'] = 'cycles',
 		['hash'] = `cruiser`,
-		['shop'] = 'pdm',
 	},
 	['fixter'] = {
 		['name'] = 'Fixter',
@@ -345,7 +308,6 @@ QBShared.Vehicles = {
 		['price'] = 225,
 		['category'] = 'cycles',
 		['hash'] = `fixter`,
-		['shop'] = 'pdm',
 	},
 	['scorcher'] = {
 		['name'] = 'Scorcher',
@@ -354,7 +316,6 @@ QBShared.Vehicles = {
 		['price'] = 280,
 		['category'] = 'cycles',
 		['hash'] = `scorcher`,
-		['shop'] = 'pdm',
 	},
 	['tribike'] = {
 		['name'] = 'Tri Bike',
@@ -363,7 +324,6 @@ QBShared.Vehicles = {
 		['price'] = 500,
 		['category'] = 'cycles',
 		['hash'] = `tribike`,
-		['shop'] = 'pdm',
 	},
 	['tribike2'] = {
 		['name'] = 'Tri Bike 2',
@@ -372,7 +332,6 @@ QBShared.Vehicles = {
 		['price'] = 700,
 		['category'] = 'cycles',
 		['hash'] = `tribike2`,
-		['shop'] = 'pdm',
 	},
 	['tribike3'] = {
 		['name'] = 'Tri Bike 3',
@@ -381,7 +340,6 @@ QBShared.Vehicles = {
 		['price'] = 520,
 		['category'] = 'cycles',
 		['hash'] = `tribike3`,
-		['shop'] = 'pdm',
 	},
 	--- Motorcycles
 	['akuma'] = {
@@ -391,7 +349,6 @@ QBShared.Vehicles = {
 		['price'] = 55000,
 		['category'] = 'motorcycles',
 		['hash'] = `akuma`,
-		['shop'] = 'pdm',
 	},
 	['avarus'] = {
 		['name'] = 'Avarus',
@@ -400,7 +357,6 @@ QBShared.Vehicles = {
 		['price'] = 20000,
 		['category'] = 'motorcycles',
 		['hash'] = `avarus`,
-		['shop'] = 'pdm',
 	},
 	['bagger'] = {
 		['name'] = 'Bagger',
@@ -409,7 +365,6 @@ QBShared.Vehicles = {
 		['price'] = 13500,
 		['category'] = 'motorcycles',
 		['hash'] = `bagger`,
-		['shop'] = 'pdm',
 	},
 	['bati'] = {
 		['name'] = 'Bati 801',
@@ -418,7 +373,6 @@ QBShared.Vehicles = {
 		['price'] = 24000,
 		['category'] = 'motorcycles',
 		['hash'] = `bati`,
-		['shop'] = 'pdm',
 	},
 	['bati2'] = {
 		['name'] = 'Bati 801RR',
@@ -427,7 +381,6 @@ QBShared.Vehicles = {
 		['price'] = 19000,
 		['category'] = 'motorcycles',
 		['hash'] = `bati2`,
-		['shop'] = 'pdm',
 	},
 	['bf400'] = {
 		['name'] = 'BF400',
@@ -436,7 +389,6 @@ QBShared.Vehicles = {
 		['price'] = 22000,
 		['category'] = 'motorcycles',
 		['hash'] = `bf400`,
-		['shop'] = 'pdm',
 	},
 	['carbonrs'] = {
 		['name'] = 'Carbon RS',
@@ -445,7 +397,6 @@ QBShared.Vehicles = {
 		['price'] = 22000,
 		['category'] = 'motorcycles',
 		['hash'] = `carbonrs`,
-		['shop'] = 'pdm',
 	},
 	['chimera'] = {
 		['name'] = 'Chimera',
@@ -454,7 +405,6 @@ QBShared.Vehicles = {
 		['price'] = 21000,
 		['category'] = 'motorcycles',
 		['hash'] = `chimera`,
-		['shop'] = 'pdm',
 	},
 	['cliffhanger'] = {
 		['name'] = 'Cliffhanger',
@@ -463,7 +413,6 @@ QBShared.Vehicles = {
 		['price'] = 28500,
 		['category'] = 'motorcycles',
 		['hash'] = `cliffhanger`,
-		['shop'] = 'pdm',
 	},
 	['daemon'] = {
 		['name'] = 'Daemon',
@@ -472,7 +421,6 @@ QBShared.Vehicles = {
 		['price'] = 14000,
 		['category'] = 'motorcycles',
 		['hash'] = `daemon`,
-		['shop'] = 'pdm',
 	},
 	['daemon2'] = {
 		['name'] = 'Daemon Custom',
@@ -481,7 +429,6 @@ QBShared.Vehicles = {
 		['price'] = 23000,
 		['category'] = 'motorcycles',
 		['hash'] = `daemon2`,
-		['shop'] = 'pdm',
 	},
 	['defiler'] = {
 		['name'] = 'Defiler',
@@ -490,7 +437,6 @@ QBShared.Vehicles = {
 		['price'] = 30000,
 		['category'] = 'motorcycles',
 		['hash'] = `defiler`,
-		['shop'] = 'pdm',
 	},
 	['deathbike'] = {							--DLC
 		['name'] = 'deathbike',
@@ -499,7 +445,6 @@ QBShared.Vehicles = {
 		['price'] = 30000,
 		['category'] = 'motorcycles',
 		['hash'] = `deathbike`,
-		['shop'] = 'pdm',
 	},
 	['deathbike2'] = {							--DLC
 		['name'] = 'deathbike2',
@@ -508,7 +453,6 @@ QBShared.Vehicles = {
 		['price'] = 30000,
 		['category'] = 'motorcycles',
 		['hash'] = `deathbike2`,
-		['shop'] = 'pdm',
 	},
 	['deathbike3'] = {							--DLC
 		['name'] = 'deathbike3',
@@ -517,7 +461,6 @@ QBShared.Vehicles = {
 		['price'] = 30000,
 		['category'] = 'motorcycles',
 		['hash'] = `deathbike3`,
-		['shop'] = 'pdm',
 	},
 	['diablous'] = {
 		['name'] = 'Diablous',
@@ -526,7 +469,6 @@ QBShared.Vehicles = {
 		['price'] = 30000,
 		['category'] = 'motorcycles',
 		['hash'] = `diablous`,
-		['shop'] = 'pdm',
 	},
 	['diablous2'] = {
 		['name'] = 'Diablous Custom',
@@ -535,7 +477,6 @@ QBShared.Vehicles = {
 		['price'] = 38000,
 		['category'] = 'motorcycles',
 		['hash'] = `diablous2`,
-		['shop'] = 'pdm',
 	},
 	['double'] = {
 		['name'] = 'Double-T',
@@ -544,7 +485,6 @@ QBShared.Vehicles = {
 		['price'] = 28000,
 		['category'] = 'motorcycles',
 		['hash'] = `double`,
-		['shop'] = 'pdm',
 	},
 	['enduro'] = {
 		['name'] = 'Enduro',
@@ -553,7 +493,6 @@ QBShared.Vehicles = {
 		['price'] = 5500,
 		['category'] = 'motorcycles',
 		['hash'] = `enduro`,
-		['shop'] = 'pdm',
 	},
 	['esskey'] = {
 		['name'] = 'Esskey',
@@ -562,7 +501,6 @@ QBShared.Vehicles = {
 		['price'] = 12000,
 		['category'] = 'motorcycles',
 		['hash'] = `esskey`,
-		['shop'] = 'pdm',
 	},
 	['faggio'] = {
 		['name'] = 'Faggio Sport',
@@ -571,7 +509,6 @@ QBShared.Vehicles = {
 		['price'] = 2000,
 		['category'] = 'motorcycles',
 		['hash'] = `faggio`,
-		['shop'] = 'pdm',
 	},
 	['faggio2'] = {
 		['name'] = 'Faggio',
@@ -580,7 +517,6 @@ QBShared.Vehicles = {
 		['price'] = 1900,
 		['category'] = 'motorcycles',
 		['hash'] = `faggio2`,
-		['shop'] = 'pdm',
 	},
 	['faggio3'] = {
 		['name'] = 'Faggio Mod',
@@ -589,7 +525,6 @@ QBShared.Vehicles = {
 		['price'] = 2500,
 		['category'] = 'motorcycles',
 		['hash'] = `faggio3`,
-		['shop'] = 'pdm',
 	},
 	['fcr'] = {
 		['name'] = 'FCR 1000',
@@ -598,7 +533,6 @@ QBShared.Vehicles = {
 		['price'] = 5000,
 		['category'] = 'motorcycles',
 		['hash'] = `fcr`,
-		['shop'] = 'pdm',
 	},
 	['fcr2'] = {
 		['name'] = 'FCR 1000 Custom',
@@ -607,7 +541,6 @@ QBShared.Vehicles = {
 		['price'] = 19000,
 		['category'] = 'motorcycles',
 		['hash'] = `fcr2`,
-		['shop'] = 'pdm',
 	},
 	['gargoyle'] = {
 		['name'] = 'Gargoyle',
@@ -616,7 +549,6 @@ QBShared.Vehicles = {
 		['price'] = 32000,
 		['category'] = 'motorcycles',
 		['hash'] = `gargoyle`,
-		['shop'] = 'pdm',
 	},
 	['hakuchou'] = {
 		['name'] = 'Hakuchou',
@@ -625,7 +557,6 @@ QBShared.Vehicles = {
 		['price'] = 17000,
 		['category'] = 'motorcycles',
 		['hash'] = `hakuchou`,
-		['shop'] = 'pdm',
 	},
 	['hakuchou2'] = {
 		['name'] = 'Hakuchou Drag',
@@ -634,7 +565,6 @@ QBShared.Vehicles = {
 		['price'] = 45000,
 		['category'] = 'motorcycles',
 		['hash'] = `hakuchou2`,
-		['shop'] = 'pdm',
 	},
 	['hexer'] = {
 		['name'] = 'Hexer',
@@ -643,7 +573,6 @@ QBShared.Vehicles = {
 		['price'] = 16000,
 		['category'] = 'motorcycles',
 		['hash'] = `hexer`,
-		['shop'] = 'pdm',
 	},
 	['innovation'] = {
 		['name'] = 'Innovation',
@@ -652,7 +581,6 @@ QBShared.Vehicles = {
 		['price'] = 33500,
 		['category'] = 'motorcycles',
 		['hash'] = `innovation`,
-		['shop'] = 'pdm',
 	},
 	['lectro'] = {
 		['name'] = 'Lectro',
@@ -661,7 +589,6 @@ QBShared.Vehicles = {
 		['price'] = 28000,
 		['category'] = 'motorcycles',
 		['hash'] = `lectro`,
-		['shop'] = 'pdm',
 	},
 	['manchez'] = {
 		['name'] = 'Manchez',
@@ -670,7 +597,6 @@ QBShared.Vehicles = {
 		['price'] = 8300,
 		['category'] = 'motorcycles',
 		['hash'] = `manchez`,
-		['shop'] = 'pdm',
 	},
 	['nemesis'] = {
 		['name'] = 'Nemesis',
@@ -679,7 +605,6 @@ QBShared.Vehicles = {
 		['price'] = 20000,
 		['category'] = 'motorcycles',
 		['hash'] = `nemesis`,
-		['shop'] = 'pdm',
 	},
 	['nightblade'] = {
 		['name'] = 'Nightblade',
@@ -688,7 +613,6 @@ QBShared.Vehicles = {
 		['price'] = 23000,
 		['category'] = 'motorcycles',
 		['hash'] = `nightblade`,
-		['shop'] = 'pdm',
 	},
 	['oppressor'] = {
 		['name'] = 'Oppressor',
@@ -697,7 +621,6 @@ QBShared.Vehicles = {
 		['price'] = 9999999,
 		['category'] = 'super',
 		['hash'] = `oppressor`,
-		['shop'] = 'luxury',
 	},
 	['pcj'] = {
 		['name'] = 'PCJ-600',
@@ -706,7 +629,6 @@ QBShared.Vehicles = {
 		['price'] = 15000,
 		['category'] = 'motorcycles',
 		['hash'] = `pcj`,
-		['shop'] = 'pdm',
 	},
 	['ratbike'] = {
 		['name'] = 'Rat Bike',
@@ -715,7 +637,6 @@ QBShared.Vehicles = {
 		['price'] = 3000,
 		['category'] = 'motorcycles',
 		['hash'] = `ratbike`,
-		['shop'] = 'pdm',
 	},
 	['ruffian'] = {
 		['name'] = 'Ruffian',
@@ -724,7 +645,6 @@ QBShared.Vehicles = {
 		['price'] = 25000,
 		['category'] = 'motorcycles',
 		['hash'] = `ruffian`,
-		['shop'] = 'pdm',
 	},
 	['sanchez'] = {
 		['name'] = 'Sanchez Livery',
@@ -733,7 +653,6 @@ QBShared.Vehicles = {
 		['price'] = 5300,
 		['category'] = 'motorcycles',
 		['hash'] = `sanchez`,
-		['shop'] = 'pdm',
 	},
 	['sanchez2'] = {
 		['name'] = 'Sanchez',
@@ -742,7 +661,6 @@ QBShared.Vehicles = {
 		['price'] = 5300,
 		['category'] = 'motorcycles',
 		['hash'] = `sanchez2`,
-		['shop'] = 'pdm',
 	},
 	['sanctus'] = {
 		['name'] = 'Sanctus',
@@ -751,7 +669,6 @@ QBShared.Vehicles = {
 		['price'] = 35000,
 		['category'] = 'motorcycles',
 		['hash'] = `sanctus`,
-		['shop'] = 'pdm',
 	},
 	['shotaro'] = {
 		['name'] = 'Shotaro Concept',
@@ -760,7 +677,6 @@ QBShared.Vehicles = {
 		['price'] = 320000,
 		['category'] = 'motorcycles',
 		['hash'] = `shotaro`,
-		['shop'] = 'pdm',
 	},
 	['sovereign'] = {
 		['name'] = 'Sovereign',
@@ -769,7 +685,6 @@ QBShared.Vehicles = {
 		['price'] = 8000,
 		['category'] = 'motorcycles',
 		['hash'] = `sovereign`,
-		['shop'] = 'pdm',
 	},
 	['stryder'] = {
 		['name'] = 'Stryder',
@@ -778,7 +693,6 @@ QBShared.Vehicles = {
 		['price'] = 50000,
 		['category'] = 'motorcycles',
 		['hash'] = `stryder`,
-		['shop'] = 'pdm',
 	},
 	['thrust'] = {
 		['name'] = 'Thrust',
@@ -787,7 +701,6 @@ QBShared.Vehicles = {
 		['price'] = 22000,
 		['category'] = 'motorcycles',
 		['hash'] = `thrust`,
-		['shop'] = 'pdm',
 	},
 	['vader'] = {
 		['name'] = 'Vader',
@@ -796,7 +709,6 @@ QBShared.Vehicles = {
 		['price'] = 7200,
 		['category'] = 'motorcycles',
 		['hash'] = `vader`,
-		['shop'] = 'pdm',
 	},
 	['vindicator'] = {
 		['name'] = 'Vindicator',
@@ -805,7 +717,6 @@ QBShared.Vehicles = {
 		['price'] = 19000,
 		['category'] = 'motorcycles',
 		['hash'] = `vindicator`,
-		['shop'] = 'pdm',
 	},
 	['vortex'] = {
 		['name'] = 'Vortex',
@@ -814,7 +725,6 @@ QBShared.Vehicles = {
 		['price'] = 31000,
 		['category'] = 'motorcycles',
 		['hash'] = `vortex`,
-		['shop'] = 'pdm',
 	},
 	['wolfsbane'] = {
 		['name'] = 'Wolfsbane',
@@ -823,7 +733,6 @@ QBShared.Vehicles = {
 		['price'] = 14000,
 		['category'] = 'motorcycles',
 		['hash'] = `wolfsbane`,
-		['shop'] = 'pdm',
 	},
 	['zombiea'] = {
 		['name'] = 'Zombie Bobber',
@@ -832,7 +741,6 @@ QBShared.Vehicles = {
 		['price'] = 28000,
 		['category'] = 'motorcycles',
 		['hash'] = `zombiea`,
-		['shop'] = 'pdm',
 	},
 	['zombieb'] = {
 		['name'] = 'Zombie Chopper',
@@ -841,7 +749,6 @@ QBShared.Vehicles = {
 		['price'] = 27000,
 		['category'] = 'motorcycles',
 		['hash'] = `zombieb`,
-		['shop'] = 'pdm',
 	},
 	['manchez2'] = {
 		['name'] = 'Manchez',
@@ -850,7 +757,6 @@ QBShared.Vehicles = {
 		['price'] = 14000,
 		['category'] = 'motorcycles',
 		['hash'] = `manchez2`,
-		['shop'] = 'pdm',
 	},
 	['shinobi'] = {		--DLC +set sv_enforceGameBuild 2545
 		['name'] = 'Shinobi',
@@ -859,7 +765,6 @@ QBShared.Vehicles = {
 		['price'] = 25000,
 		['category'] = 'motorcycles',
 		['hash'] = `shinobi`,
-		['shop'] = 'pdm',
 	},
 	['reever'] = {		--DLC +set sv_enforceGameBuild 2545
 		['name'] = 'Reever',
@@ -868,7 +773,6 @@ QBShared.Vehicles = {
 		['price'] = 25000,
 		['category'] = 'motorcycles',
 		['hash'] = `reever`,
-		['shop'] = 'pdm',
 	},
 	--- Muscle
 	['blade'] = {
@@ -878,7 +782,6 @@ QBShared.Vehicles = {
 		['price'] = 23500,
 		['category'] = 'muscle',
 		['hash'] = `blade`,
-		['shop'] = 'pdm',
 	},
 	['buccaneer'] = {
 		['name'] = 'Buccaneer',
@@ -887,7 +790,6 @@ QBShared.Vehicles = {
 		['price'] = 22500,
 		['category'] = 'muscle',
 		['hash'] = `buccaneer`,
-		['shop'] = 'pdm',
 	},
 	['buccaneer2'] = {
 		['name'] = 'Buccaneer Rider',
@@ -896,7 +798,6 @@ QBShared.Vehicles = {
 		['price'] = 24500,
 		['category'] = 'muscle',
 		['hash'] = `buccaneer2`,
-		['shop'] = 'pdm',
 	},
 	['chino'] = {
 		['name'] = 'Chino',
@@ -905,7 +806,6 @@ QBShared.Vehicles = {
 		['price'] = 5000,
 		['category'] = 'muscle',
 		['hash'] = `chino`,
-		['shop'] = 'pdm',
 	},
 	['chino2'] = {
 		['name'] = 'Chino Luxe',
@@ -914,7 +814,6 @@ QBShared.Vehicles = {
 		['price'] = 8000,
 		['category'] = 'muscle',
 		['hash'] = `chino2`,
-		['shop'] = 'pdm',
 	},
 	['clique'] = {							--DLC
 		['name'] = 'Clique',
@@ -923,7 +822,6 @@ QBShared.Vehicles = {
 		['price'] = 20000,
 		['category'] = 'muscle',
 		['hash'] = `clique`,
-		['shop'] = 'pdm',
 	},
 	['coquette3'] = {
 		['name'] = 'Coquette BlackFin',
@@ -932,7 +830,6 @@ QBShared.Vehicles = {
 		['price'] = 180000,
 		['category'] = 'muscle',
 		['hash'] = `coquette3`,
-		['shop'] = 'pdm',
 	},
 	['deviant'] = {							--DLC
 		['name'] = 'Deviant',
@@ -941,7 +838,6 @@ QBShared.Vehicles = {
 		['price'] = 70000,
 		['category'] = 'muscle',
 		['hash'] = `deviant`,
-		['shop'] = 'pdm',
 	},
 	['dominator'] = {
 		['name'] = 'Dominator',
@@ -950,7 +846,6 @@ QBShared.Vehicles = {
 		['price'] = 62500,
 		['category'] = 'muscle',
 		['hash'] = `dominator`,
-		['shop'] = 'pdm',
 	},
 	['dominator2'] = {
 		['name'] = 'Pißwasser Dominator',
@@ -959,7 +854,6 @@ QBShared.Vehicles = {
 		['price'] = 50000,
 		['category'] = 'muscle',
 		['hash'] = `dominator2`,
-		['shop'] = 'pdm',
 	},
 	['dominator3'] = {
 		['name'] = 'Dominator GTX',
@@ -968,7 +862,6 @@ QBShared.Vehicles = {
 		['price'] = 70000,
 		['category'] = 'muscle',
 		['hash'] = `dominator3`,
-		['shop'] = 'pdm',
 	},
 	['dominator4'] = {							--DLC
 		['name'] = 'Dominator Arena',
@@ -977,7 +870,6 @@ QBShared.Vehicles = {
 		['price'] = 200000,
 		['category'] = 'muscle',
 		['hash'] = `dominator4`,
-		['shop'] = 'pdm',
 	},
 	['dominator7'] = {							--DLC +set sv_enforceGameBuild 2372
 		['name'] = 'Dominator ASP',
@@ -986,7 +878,6 @@ QBShared.Vehicles = {
 		['price'] = 110000,
 		['category'] = 'muscle',
 		['hash'] = `dominator7`,
-		['shop'] = 'pdm',
 	},
 	['dominator8'] = {							--DLC +set sv_enforceGameBuild 2372
 		['name'] = 'Dominator GTT',
@@ -995,7 +886,6 @@ QBShared.Vehicles = {
 		['price'] = 80000,
 		['category'] = 'muscle',
 		['hash'] = `dominator8`,
-		['shop'] = 'pdm',
 	},
 	['dukes'] = {
 		['name'] = 'Dukes',
@@ -1004,7 +894,6 @@ QBShared.Vehicles = {
 		['price'] = 23500,
 		['category'] = 'muscle',
 		['hash'] = `dukes`,
-		['shop'] = 'pdm',
 	},
 	['dukes2'] = {
 		['name'] = 'Dukes Nightrider',
@@ -1013,7 +902,6 @@ QBShared.Vehicles = {
 		['price'] = 60000,
 		['category'] = 'muscle',
 		['hash'] = `dukes2`,
-		['shop'] = 'pdm',
 	},
 	['dukes3'] = {
 		['name'] = 'Beater Dukes',
@@ -1022,7 +910,6 @@ QBShared.Vehicles = {
 		['price'] = 45000,
 		['category'] = 'muscle',
 		['hash'] = `dukes3`,
-		['shop'] = 'pdm',
 	},
 	['faction'] = {
 		['name'] = 'Faction',
@@ -1031,7 +918,6 @@ QBShared.Vehicles = {
 		['price'] = 17000,
 		['category'] = 'muscle',
 		['hash'] = `faction`,
-		['shop'] = 'pdm',
 	},
 	['faction2'] = {
 		['name'] = 'Faction Rider',
@@ -1040,7 +926,6 @@ QBShared.Vehicles = {
 		['price'] = 19000,
 		['category'] = 'muscle',
 		['hash'] = `faction2`,
-		['shop'] = 'pdm',
 	},
 	['faction3'] = {
 		['name'] = 'Faction Custom Donk',
@@ -1049,7 +934,6 @@ QBShared.Vehicles = {
 		['price'] = 35000,
 		['category'] = 'muscle',
 		['hash'] = `faction3`,
-		['shop'] = 'pdm',
 	},
 	['ellie'] = {
 		['name'] = 'Ellie',
@@ -1058,7 +942,6 @@ QBShared.Vehicles = {
 		['price'] = 42250,
 		['category'] = 'muscle',
 		['hash'] = `ellie`,
-		['shop'] = 'pdm',
 	},
 	['gauntlet'] = {
 		['name'] = 'Gauntlet',
@@ -1067,7 +950,6 @@ QBShared.Vehicles = {
 		['price'] = 28500,
 		['category'] = 'muscle',
 		['hash'] = `gauntlet`,
-		['shop'] = 'pdm',
 	},
 	['gauntlet2'] = {
 		['name'] = 'Redwood Gauntlet',
@@ -1076,7 +958,6 @@ QBShared.Vehicles = {
 		['price'] = 70000,
 		['category'] = 'muscle',
 		['hash'] = `gauntlet2`,
-		['shop'] = 'pdm',
 	},
 	['gauntlet3'] = {							--DLC
 		['name'] = 'Classic Gauntlet',
@@ -1085,7 +966,6 @@ QBShared.Vehicles = {
 		['price'] = 75000,
 		['category'] = 'muscle',
 		['hash'] = `gauntlet3`,
-		['shop'] = 'pdm',
 	},
 	['gauntlet4'] = {							--DLC
 		['name'] = 'Gauntlet Hellfire',
@@ -1094,7 +974,6 @@ QBShared.Vehicles = {
 		['price'] = 80000,
 		['category'] = 'muscle',
 		['hash'] = `gauntlet4`,
-		['shop'] = 'pdm',
 	},
 	['gauntlet5'] = {
 		['name'] = 'Gauntlet Classic Custom',
@@ -1103,7 +982,6 @@ QBShared.Vehicles = {
 		['price'] = 120000,
 		['category'] = 'muscle',
 		['hash'] = `gauntlet5`,
-		['shop'] = 'pdm',
 	},
 	['hermes'] = {
 		['name'] = 'Hermes',
@@ -1112,7 +990,6 @@ QBShared.Vehicles = {
 		['price'] = 535000,
 		['category'] = 'muscle',
 		['hash'] = `hermes`,
-		['shop'] = 'pdm',
 	},
 	['hotknife'] = {
 		['name'] = 'Hotknife',
@@ -1121,7 +998,6 @@ QBShared.Vehicles = {
 		['price'] = 90000,
 		['category'] = 'muscle',
 		['hash'] = `hotknife`,
-		['shop'] = 'pdm',
 	},
 	['hustler'] = {
 		['name'] = 'Hustler',
@@ -1130,7 +1006,6 @@ QBShared.Vehicles = {
 		['price'] = 95000,
 		['category'] = 'muscle',
 		['hash'] = `hustler`,
-		['shop'] = 'pdm',
 	},
 	['impaler'] = {							--DLC
 		['name'] = 'impaler',
@@ -1139,7 +1014,6 @@ QBShared.Vehicles = {
 		['price'] = 95000,
 		['category'] = 'muscle',
 		['hash'] = `impaler`,
-		['shop'] = 'pdm',
 	},
 	['impaler2'] = {							--DLC
 		['name'] = 'impaler2',
@@ -1148,7 +1022,6 @@ QBShared.Vehicles = {
 		['price'] = 95000,
 		['category'] = 'muscle',
 		['hash'] = `impaler2`,
-		['shop'] = 'pdm',
 	},
 	['impaler3'] = {							--DLC
 		['name'] = 'impaler3',
@@ -1157,7 +1030,6 @@ QBShared.Vehicles = {
 		['price'] = 95000,
 		['category'] = 'muscle',
 		['hash'] = `impaler3`,
-		['shop'] = 'pdm',
 	},
 	['impaler4'] = {							--DLC
 		['name'] = 'impaler4',
@@ -1166,7 +1038,6 @@ QBShared.Vehicles = {
 		['price'] = 95000,
 		['category'] = 'muscle',
 		['hash'] = `impaler4`,
-		['shop'] = 'pdm',
 	},
 	['imperator'] = {							--DLC
 		['name'] = 'imperator',
@@ -1175,7 +1046,6 @@ QBShared.Vehicles = {
 		['price'] = 95000,
 		['category'] = 'muscle',
 		['hash'] = `imperator`,
-		['shop'] = 'pdm',
 	},
 	['imperator2'] = {							--DLC
 		['name'] = 'imperator2',
@@ -1184,7 +1054,6 @@ QBShared.Vehicles = {
 		['price'] = 95000,
 		['category'] = 'muscle',
 		['hash'] = `imperator2`,
-		['shop'] = 'pdm',
 	},
 	['imperator3'] = {							--DLC
 		['name'] = 'imperator3',
@@ -1193,7 +1062,6 @@ QBShared.Vehicles = {
 		['price'] = 95000,
 		['category'] = 'muscle',
 		['hash'] = `imperator3`,
-		['shop'] = 'pdm',
 	},
 	['lurcher'] = {
 		['name'] = 'Gauntlet Classic Custom',
@@ -1202,7 +1070,6 @@ QBShared.Vehicles = {
 		['price'] = 21000,
 		['category'] = 'muscle',
 		['hash'] = `lurcher`,
-		['shop'] = 'pdm',
 	},
 	['moonbeam'] = {
 		['name'] = 'Moonbeam',
@@ -1211,7 +1078,6 @@ QBShared.Vehicles = {
 		['price'] = 13000,
 		['category'] = 'vans',
 		['hash'] = `moonbeam`,
-		['shop'] = 'pdm',
 	},
 	['moonbeam2'] = {
 		['name'] = 'Moonbeam Custom',
@@ -1220,7 +1086,6 @@ QBShared.Vehicles = {
 		['price'] = 15000,
 		['category'] = 'vans',
 		['hash'] = `moonbeam2`,
-		['shop'] = 'pdm',
 	},
 	['nightshade'] = {
 		['name'] = 'Nightshade',
@@ -1229,7 +1094,6 @@ QBShared.Vehicles = {
 		['price'] = 70000,
 		['category'] = 'muscle',
 		['hash'] = `nightshade`,
-		['shop'] = 'pdm',
 	},
 	['peyote2'] = {							--DLC
 		['name'] = 'Peyote Gasser',
@@ -1238,7 +1102,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'sportsclassics',
 		['hash'] = `peyote2`,
-		['shop'] = 'pdm',
 	},
 	['phoenix'] = {
 		['name'] = 'Phoenix',
@@ -1247,7 +1110,6 @@ QBShared.Vehicles = {
 		['price'] = 65000,
 		['category'] = 'muscle',
 		['hash'] = `phoenix`,
-		['shop'] = 'pdm',
 	},
 	['picador'] = {
 		['name'] = 'Picador',
@@ -1256,7 +1118,6 @@ QBShared.Vehicles = {
 		['price'] = 20000,
 		['category'] = 'muscle',
 		['hash'] = `picador`,
-		['shop'] = 'pdm',
 	},
 	['ratloader2'] = {
 		['name'] = 'ratloader2',
@@ -1265,7 +1126,6 @@ QBShared.Vehicles = {
 		['price'] = 20000,
 		['category'] = 'muscle',
 		['hash'] = `ratloader2`,
-		['shop'] = 'pdm',
 	},
 	['ruiner'] = {
 		['name'] = 'Ruiner',
@@ -1274,7 +1134,6 @@ QBShared.Vehicles = {
 		['price'] = 29000,
 		['category'] = 'muscle',
 		['hash'] = `ruiner`,
-		['shop'] = 'pdm',
 	},
 	['ruiner2'] = {
 		['name'] = 'Ruiner 2000',
@@ -1283,7 +1142,6 @@ QBShared.Vehicles = {
 		['price'] = 50000,
 		['category'] = 'muscle',
 		['hash'] = `ruiner2`,
-		['shop'] = 'pdm',
 	},
 	['sabregt'] = {
 		['name'] = 'Sabre Turbo',
@@ -1292,7 +1150,6 @@ QBShared.Vehicles = {
 		['price'] = 23000,
 		['category'] = 'muscle',
 		['hash'] = `sabregt`,
-		['shop'] = 'pdm',
 	},
 	['sabregt2'] = {
 		['name'] = 'Sabre GT',
@@ -1301,7 +1158,6 @@ QBShared.Vehicles = {
 		['price'] = 26500,
 		['category'] = 'muscle',
 		['hash'] = `sabregt2`,
-		['shop'] = 'pdm',
 	},
 	['slamvan'] = {
 		['name'] = 'Slam Van',
@@ -1310,7 +1166,6 @@ QBShared.Vehicles = {
 		['price'] = 30000,
 		['category'] = 'muscle',
 		['hash'] = `slamvan`,
-		['shop'] = 'pdm',
 	},
 	['slamvan2'] = {
 		['name'] = 'Lost Slam Van',
@@ -1319,7 +1174,6 @@ QBShared.Vehicles = {
 		['price'] = 90000,
 		['category'] = 'muscle',
 		['hash'] = `slamvan2`,
-		['shop'] = 'pdm',
 	},
 	['slamvan3'] = {
 		['name'] = 'Slam Van Custom',
@@ -1328,7 +1182,6 @@ QBShared.Vehicles = {
 		['price'] = 17000,
 		['category'] = 'muscle',
 		['hash'] = `slamvan3`,
-		['shop'] = 'pdm',
 	},
 	['stalion'] = {
 		['name'] = 'Stallion',
@@ -1337,7 +1190,6 @@ QBShared.Vehicles = {
 		['price'] = 33000,
 		['category'] = 'muscle',
 		['hash'] = `stalion`,
-		['shop'] = 'pdm',
 	},
 	['stalion2'] = {
 		['name'] = 'Stallion Burgershot',
@@ -1346,7 +1198,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'muscle',
 		['hash'] = `stalion2`,
-		['shop'] = 'pdm',
 	},
 	['tampa'] = {
 		['name'] = 'Tampa',
@@ -1355,7 +1206,6 @@ QBShared.Vehicles = {
 		['price'] = 24500,
 		['category'] = 'muscle',
 		['hash'] = `tampa`,
-		['shop'] = 'pdm',
 	},
 	['tulip'] = {							--DLC
 		['name'] = 'Tulip',
@@ -1364,7 +1214,6 @@ QBShared.Vehicles = {
 		['price'] = 80000,
 		['category'] = 'muscle',
 		['hash'] = `tulip`,
-		['shop'] = 'pdm',
 	},
 	['vamos'] = {							--DLC
 		['name'] = 'Vamos',
@@ -1373,7 +1222,6 @@ QBShared.Vehicles = {
 		['price'] = 30000,
 		['category'] = 'muscle',
 		['hash'] = `vamos`,
-		['shop'] = 'pdm',
 	},
 	['vigero'] = {
 		['name'] = 'Vigero',
@@ -1382,7 +1230,6 @@ QBShared.Vehicles = {
 		['price'] = 39500,
 		['category'] = 'muscle',
 		['hash'] = `vigero`,
-		['shop'] = 'pdm',
 	},
 	['virgo'] = {
 		['name'] = 'Virgo',
@@ -1391,7 +1238,6 @@ QBShared.Vehicles = {
 		['price'] = 22000,
 		['category'] = 'muscle',
 		['hash'] = `virgo`,
-		['shop'] = 'pdm',
 	},
 	['virgo2'] = {
 		['name'] = 'Virgo Custom Classic',
@@ -1400,7 +1246,6 @@ QBShared.Vehicles = {
 		['price'] = 21000,
 		['category'] = 'muscle',
 		['hash'] = `virgo2`,
-		['shop'] = 'pdm',
 	},
 	['virgo3'] = {
 		['name'] = 'Virgo Custom Classic',
@@ -1409,7 +1254,6 @@ QBShared.Vehicles = {
 		['price'] = 21000,
 		['category'] = 'muscle',
 		['hash'] = `virgo3`,
-		['shop'] = 'pdm',
 	},
 	['voodoo'] = {
 		['name'] = 'Voodoo',
@@ -1418,7 +1262,6 @@ QBShared.Vehicles = {
 		['price'] = 13000,
 		['category'] = 'muscle',
 		['hash'] = `voodoo`,
-		['shop'] = 'pdm',
 	},
 	['yosemite'] = {
 		['name'] = 'Yosemite',
@@ -1427,7 +1270,6 @@ QBShared.Vehicles = {
 		['price'] = 19500,
 		['category'] = 'muscle',
 		['hash'] = `yosemite`,
-		['shop'] = 'pdm',
 	},
 	['yosemite2'] = {
 		['name'] = 'Yosemite Drift',
@@ -1436,7 +1278,6 @@ QBShared.Vehicles = {
 		['price'] = 55000,
 		['category'] = 'muscle',
 		['hash'] = `yosemite2`,
-		['shop'] = 'pdm',
 	},
 	['yosemite3'] = {
 		['name'] = 'Yosemite Rancher',
@@ -1445,7 +1286,6 @@ QBShared.Vehicles = {
 		['category'] = 'offroad',
 		['model'] = 'yosemite3',
 		['hash'] = `yosemite3`,
-		['shop'] = 'pdm',
 	},
 	['buffalo4'] = { 	 	--DLC +set sv_enforceGameBuild 2545
 		['name'] = 'Buffalo STX',
@@ -1454,7 +1294,6 @@ QBShared.Vehicles = {
 		['price'] = 345000,
 		['category'] = 'muscle',
 		['hash'] = `buffalo4`,
-		['shop'] = 'pdm',
 	},
 	--- Off-Road
 	['bfinjection'] = {
@@ -1464,7 +1303,6 @@ QBShared.Vehicles = {
 		['category'] = 'offroad',
 		['model'] = 'bfinjection',
 		['hash'] = `bfinjection`,
-		['shop'] = 'pdm',
 	},
 	['bifta'] = {
 		['name'] = 'Bifta',
@@ -1473,7 +1311,6 @@ QBShared.Vehicles = {
 		['category'] = 'offroad',
 		['model'] = 'bifta',
 		['hash'] = `bifta`,
-		['shop'] = 'pdm',
 	},
 	['blazer'] = {
 		['name'] = 'Blazer',
@@ -1482,7 +1319,6 @@ QBShared.Vehicles = {
 		['category'] = 'offroad',
 		['model'] = 'blazer',
 		['hash'] = `blazer`,
-		['shop'] = 'pdm',
 	},
 	['blazer2'] = {
 		['name'] = 'Blazer Lifeguard',
@@ -1491,7 +1327,6 @@ QBShared.Vehicles = {
 		['price'] = 7000,
 		['category'] = 'offroad',
 		['hash'] = `blazer2`,
-		['shop'] = 'pdm',
 	},
 	['blazer3'] = {
 		['name'] = 'Blazer Hot Rod',
@@ -1500,7 +1335,6 @@ QBShared.Vehicles = {
 		['price'] = 7000,
 		['category'] = 'offroad',
 		['hash'] = `blazer3`,
-		['shop'] = 'pdm',
 	},
 	['blazer4'] = {
 		['name'] = 'Blazer Sport',
@@ -1509,7 +1343,6 @@ QBShared.Vehicles = {
 		['category'] = 'offroad',
 		['model'] = 'blazer4',
 		['hash'] = `blazer4`,
-		['shop'] = 'pdm',
 	},
 	['blazer5'] = {
 		['name'] = 'Blazer Aqua',
@@ -1518,7 +1351,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'offroad',
 		['hash'] = `blazer5`,
-		['shop'] = 'pdm',
 	},
 	['brawler'] = {
 		['name'] = 'Brawler',
@@ -1527,7 +1359,6 @@ QBShared.Vehicles = {
 		['category'] = 'offroad',
 		['model'] = 'brawler',
 		['hash'] = `brawler`,
-		['shop'] = 'pdm',
 	},
 	['caracara'] = {
 		['name'] = 'Caracara',
@@ -1536,7 +1367,6 @@ QBShared.Vehicles = {
 		['price'] = 60000,
 		['category'] = 'offroad',
 		['hash'] = `caracara`,
-		['shop'] = 'pdm',
 	},
 	['caracara2'] = {							--DLC
 		['name'] = 'Caracara 4x4',
@@ -1545,7 +1375,6 @@ QBShared.Vehicles = {
 		['price'] = 80000,
 		['category'] = 'offroad',
 		['hash'] = `caracara2`,
-		['shop'] = 'pdm',
 	},
 	['dubsta3'] = {
 		['name'] = 'Dubsta 6x6',
@@ -1554,7 +1383,6 @@ QBShared.Vehicles = {
 		['category'] = 'offroad',
 		['model'] = 'dubsta3',
 		['hash'] = `dubsta3`,
-		['shop'] = 'pdm',
 	},
 	['dune'] = {
 		['name'] = 'Dune Buggy',
@@ -1563,7 +1391,6 @@ QBShared.Vehicles = {
 		['category'] = 'offroad',
 		['model'] = 'dune',
 		['hash'] = `dune`,
-		['shop'] = 'pdm',
 	},
 	['everon'] = {
 		['name'] = 'Everon',
@@ -1572,7 +1399,6 @@ QBShared.Vehicles = {
 		['price'] = 60000,
 		['category'] = 'offroad',
 		['hash'] = `everon`,
-		['shop'] = 'pdm',
 	},
 	['freecrawler'] = {							--DLC
 		['name'] = 'Freecrawler',
@@ -1581,7 +1407,6 @@ QBShared.Vehicles = {
 		['price'] = 24000,
 		['category'] = 'offroad',
 		['hash'] = `freecrawler`,
-		['shop'] = 'pdm',
 	},
 	['hellion'] = {							--DLC
 		['name'] = 'Hellion',
@@ -1590,7 +1415,6 @@ QBShared.Vehicles = {
 		['price'] = 38000,
 		['category'] = 'offroad',
 		['hash'] = `hellion`,
-		['shop'] = 'pdm',
 	},
 	['kalahari'] = {
 		['name'] = 'Kalahari',
@@ -1599,7 +1423,6 @@ QBShared.Vehicles = {
 		['price'] = 14000,
 		['category'] = 'offroad',
 		['hash'] = `kalahari`,
-		['shop'] = 'pdm',
 	},
 	['kamacho'] = {
 		['name'] = 'Kamacho',
@@ -1608,7 +1431,6 @@ QBShared.Vehicles = {
 		['price'] = 50000,
 		['category'] = 'offroad',
 		['hash'] = `kamacho`,
-		['shop'] = 'pdm',
 	},
 	['mesa3'] = {
 		['name'] = 'Mesa Merryweather',
@@ -1617,7 +1439,6 @@ QBShared.Vehicles = {
 		['price'] = 400000,
 		['category'] = 'offroad',
 		['hash'] = `mesa3`,
-		['shop'] = 'pdm',
 	},
 	['outlaw'] = {
 		['name'] = 'Outlaw',
@@ -1626,7 +1447,6 @@ QBShared.Vehicles = {
 		['price'] = 15000,
 		['category'] = 'offroad',
 		['hash'] = `outlaw`,
-		['shop'] = 'pdm',
 	},
 	['rancherxl'] = {
 		['name'] = 'Rancher XL',
@@ -1635,7 +1455,6 @@ QBShared.Vehicles = {
 		['price'] = 24000,
 		['category'] = 'offroad',
 		['hash'] = `rancherxl`,
-		['shop'] = 'pdm',
 	},
 	['rebel2'] = {
 		['name'] = 'Rebel',
@@ -1644,7 +1463,6 @@ QBShared.Vehicles = {
 		['price'] = 20000,
 		['category'] = 'offroad',
 		['hash'] = `rebel2`,
-		['shop'] = 'pdm',
 	},
 	['riata'] = {
 		['name'] = 'Riata',
@@ -1653,7 +1471,6 @@ QBShared.Vehicles = {
 		['price'] = 380000,
 		['category'] = 'offroad',
 		['hash'] = `riata`,
-		['shop'] = 'pdm',
 	},
 	['sandking'] = {
 		['name'] = 'Sandking',
@@ -1662,7 +1479,6 @@ QBShared.Vehicles = {
 		['category'] = 'offroad',
 		['model'] = 'sandking',
 		['hash'] = `sandking`,
-		['shop'] = 'pdm',
 	},
 	['sandking2'] = {
 		['name'] = 'Sandking SWB',
@@ -1671,7 +1487,6 @@ QBShared.Vehicles = {
 		['category'] = 'offroad',
 		['model'] = 'sandking2',
 		['hash'] = `sandking2`,
-		['shop'] = 'pdm',
 	},
 	['trophytruck'] = {
 		['name'] = 'Trophy Truck',
@@ -1680,7 +1495,6 @@ QBShared.Vehicles = {
 		['category'] = 'offroad',
 		['model'] = 'trophytruck',
 		['hash'] = `trophytruck`,
-		['shop'] = 'pdm',
 	},
 	['trophytruck2'] = {
 		['name'] = 'Trophy Truck Limited',
@@ -1689,7 +1503,6 @@ QBShared.Vehicles = {
 		['category'] = 'offroad',
 		['model'] = 'trophytruck2',
 		['hash'] = `trophytruck2`,
-		['shop'] = 'pdm',
 	},
 	['vagrant'] = {
 		['name'] = 'Vagrant',
@@ -1698,7 +1511,6 @@ QBShared.Vehicles = {
 		['category'] = 'offroad',
 		['model'] = 'vagrant',
 		['hash'] = `vagrant`,
-		['shop'] = 'pdm',
 	},
 	['verus'] = {
 		['name'] = 'Verus',
@@ -1707,7 +1519,6 @@ QBShared.Vehicles = {
 		['category'] = 'offroad',
 		['model'] = 'verus',
 		['hash'] = `verus`,
-		['shop'] = 'pdm',
 	},
 	['winky'] = {
 		['name'] = 'Winky',
@@ -1716,7 +1527,6 @@ QBShared.Vehicles = {
 		['category'] = 'offroad',
 		['model'] = 'winky',
 		['hash'] = `winky`,
-		['shop'] = 'pdm',
 	},
 	--- SUVs
 	['baller'] = {
@@ -1726,7 +1536,6 @@ QBShared.Vehicles = {
 		['price'] = 22000,
 		['category'] = 'suvs',
 		['hash'] = `baller`,
-		['shop'] = 'pdm',
 	},
 	['baller2'] = {
 		['name'] = 'Baller',
@@ -1735,7 +1544,6 @@ QBShared.Vehicles = {
 		['price'] = 15000,
 		['category'] = 'suvs',
 		['hash'] = `baller2`,
-		['shop'] = 'pdm',
 	},
 	['baller3'] = {
 		['name'] = 'Baller LE',
@@ -1744,7 +1552,6 @@ QBShared.Vehicles = {
 		['price'] = 15000,
 		['category'] = 'suvs',
 		['hash'] = `baller3`,
-		['shop'] = 'pdm',
 	},
 	['baller4'] = {
 		['name'] = 'Baller LE LWB',
@@ -1753,7 +1560,6 @@ QBShared.Vehicles = {
 		['price'] = 29000,
 		['category'] = 'suvs',
 		['hash'] = `baller4`,
-		['shop'] = 'pdm',
 	},
 	['baller5'] = {
 		['name'] = 'Baller LE (Armored)',
@@ -1762,7 +1568,6 @@ QBShared.Vehicles = {
 		['price'] = 78000,
 		['category'] = 'suvs',
 		['hash'] = `baller5`,
-		['shop'] = 'pdm',
 	},
 	['baller6'] = {
 		['name'] = 'Baller LE LWB (Armored)',
@@ -1771,7 +1576,6 @@ QBShared.Vehicles = {
 		['price'] = 82000,
 		['category'] = 'suvs',
 		['hash'] = `baller6`,
-		['shop'] = 'pdm',
 	},
 	['bjxl'] = {
 		['name'] = 'BeeJay XL',
@@ -1780,7 +1584,6 @@ QBShared.Vehicles = {
 		['price'] = 19000,
 		['category'] = 'suvs',
 		['hash'] = `bjxl`,
-		['shop'] = 'pdm',
 	},
 	['cavalcade'] = {
 		['name'] = 'Cavalcade',
@@ -1789,7 +1592,6 @@ QBShared.Vehicles = {
 		['price'] = 14000,
 		['category'] = 'suvs',
 		['hash'] = `cavalcade`,
-		['shop'] = 'pdm',
 	},
 	['cavalcade2'] = {
 		['name'] = 'Cavalcade',
@@ -1798,7 +1600,6 @@ QBShared.Vehicles = {
 		['price'] = 16500,
 		['category'] = 'suvs',
 		['hash'] = `cavalcade2`,
-		['shop'] = 'pdm',
 	},
 	['contender'] = {
 		['name'] = 'Contender',
@@ -1807,7 +1608,6 @@ QBShared.Vehicles = {
 		['price'] = 35000,
 		['category'] = 'suvs',
 		['hash'] = `contender`,
-		['shop'] = 'pdm',
 	},
 	['dubsta'] = {
 		['name'] = 'Dubsta',
@@ -1816,7 +1616,6 @@ QBShared.Vehicles = {
 		['price'] = 19000,
 		['category'] = 'suvs',
 		['hash'] = `dubsta`,
-		['shop'] = 'pdm',
 	},
 	['dubsta2'] = {
 		['name'] = 'Dubsta Luxuary',
@@ -1825,7 +1624,6 @@ QBShared.Vehicles = {
 		['price'] = 19500,
 		['category'] = 'suvs',
 		['hash'] = `dubsta2`,
-		['shop'] = 'pdm',
 	},
 	['fq2'] = {
 		['name'] = 'FQ2',
@@ -1834,7 +1632,6 @@ QBShared.Vehicles = {
 		['price'] = 18500,
 		['category'] = 'suvs',
 		['hash'] = `fq2`,
-		['shop'] = 'pdm',
 	},
 	['granger'] = {
 		['name'] = 'Granger',
@@ -1843,7 +1640,6 @@ QBShared.Vehicles = {
 		['price'] = 22000,
 		['category'] = 'suvs',
 		['hash'] = `granger`,
-		['shop'] = 'pdm',
 	},
 	['gresley'] = {
 		['name'] = 'Gresley',
@@ -1852,7 +1648,6 @@ QBShared.Vehicles = {
 		['price'] = 25000,
 		['category'] = 'suvs',
 		['hash'] = `gresley`,
-		['shop'] = 'pdm',
 	},
 	['habanero'] = {
 		['name'] = 'Habanero',
@@ -1861,7 +1656,6 @@ QBShared.Vehicles = {
 		['price'] = 20000,
 		['category'] = 'suvs',
 		['hash'] = `habanero`,
-		['shop'] = 'pdm',
 	},
 	['huntley'] = {
 		['name'] = 'Huntley S',
@@ -1870,7 +1664,6 @@ QBShared.Vehicles = {
 		['price'] = 24500,
 		['category'] = 'suvs',
 		['hash'] = `huntley`,
-		['shop'] = 'pdm',
 	},
 	['landstalker'] = {
 		['name'] = 'Landstalker',
@@ -1879,7 +1672,6 @@ QBShared.Vehicles = {
 		['price'] = 12000,
 		['category'] = 'suvs',
 		['hash'] = `landstalker`,
-		['shop'] = 'pdm',
 	},
 	['landstalker2'] = {
 		['name'] = 'Landstalker XL',
@@ -1888,7 +1680,6 @@ QBShared.Vehicles = {
 		['price'] = 26000,
 		['category'] = 'suvs',
 		['hash'] = `landstalker2`,
-		['shop'] = 'pdm',
 	},
 	['mesa'] = {
 		['name'] = 'Mesa',
@@ -1897,7 +1688,6 @@ QBShared.Vehicles = {
 		['price'] = 12000,
 		['category'] = 'offroad',
 		['hash'] = `mesa`,
-		['shop'] = 'pdm',
 	},
 	['novak'] = {							--DLC
 		['name'] = 'Novak',
@@ -1906,7 +1696,6 @@ QBShared.Vehicles = {
 		['price'] = 70000,
 		['category'] = 'suvs',
 		['hash'] = `novak`,
-		['shop'] = 'pdm',
 	},
 	['patriot'] = {
 		['name'] = 'Patriot',
@@ -1915,7 +1704,6 @@ QBShared.Vehicles = {
 		['price'] = 21000,
 		['category'] = 'suvs',
 		['hash'] = `patriot`,
-		['shop'] = 'pdm',
 	},
 	['radi'] = {
 		['name'] = 'Radius',
@@ -1924,7 +1712,6 @@ QBShared.Vehicles = {
 		['price'] = 18000,
 		['category'] = 'suvs',
 		['hash'] = `radi`,
-		['shop'] = 'pdm',
 	},
 	['rebla'] = {
 		['name'] = 'Rebla GTS',
@@ -1933,7 +1720,6 @@ QBShared.Vehicles = {
 		['price'] = 21000,
 		['category'] = 'suvs',
 		['hash'] = `rebla`,
-		['shop'] = 'pdm',
 	},
 	['rocoto'] = {
 		['name'] = 'Rocoto',
@@ -1942,7 +1728,6 @@ QBShared.Vehicles = {
 		['price'] = 13000,
 		['category'] = 'suvs',
 		['hash'] = `rocoto`,
-		['shop'] = 'pdm',
 	},
 	['seminole'] = {
 		['name'] = 'Seminole',
@@ -1951,7 +1736,6 @@ QBShared.Vehicles = {
 		['price'] = 20000,
 		['category'] = 'suvs',
 		['hash'] = `seminole`,
-		['shop'] = 'pdm',
 	},
 	['seminole2'] = {
 		['name'] = 'Seminole Frontier',
@@ -1960,7 +1744,6 @@ QBShared.Vehicles = {
 		['price'] = 13000,
 		['category'] = 'suvs',
 		['hash'] = `seminole2`,
-		['shop'] = 'pdm',
 	},
 	['serrano'] = {
 		['name'] = 'Serrano',
@@ -1969,7 +1752,6 @@ QBShared.Vehicles = {
 		['price'] = 48000,
 		['category'] = 'suvs',
 		['hash'] = `serrano`,
-		['shop'] = 'pdm',
 	},
 	['toros'] = {							--DLC
 		['name'] = 'Toros',
@@ -1978,7 +1760,6 @@ QBShared.Vehicles = {
 		['price'] = 65000,
 		['category'] = 'suvs',
 		['hash'] = `toros`,
-		['shop'] = 'pdm',
 	},
 	['xls'] = {
 		['name'] = 'XLS',
@@ -1987,7 +1768,6 @@ QBShared.Vehicles = {
 		['price'] = 17000,
 		['category'] = 'suvs',
 		['hash'] = `xls`,
-		['shop'] = 'pdm',
 	},
 	['granger2'] = { 	 	--DLC +set sv_enforceGameBuild 2545
 		['name'] = 'Granger 3600LX',
@@ -1996,7 +1776,6 @@ QBShared.Vehicles = {
 		['price'] = 221000,
 		['category'] = 'suvs',
 		['hash'] = `granger2`,
-		['shop'] = 'pdm',
 	},
 	--- Sedans
 	['asea'] = {
@@ -2006,7 +1785,6 @@ QBShared.Vehicles = {
 		['price'] = 2500,
 		['category'] = 'sedans',
 		['hash'] = `asea`,
-		['shop'] = 'pdm',
 	},
 	['asterope'] = {
 		['name'] = 'Asterope',
@@ -2015,7 +1793,6 @@ QBShared.Vehicles = {
 		['price'] = 11000,
 		['category'] = 'sedans',
 		['hash'] = `asterope`,
-		['shop'] = 'pdm',
 	},
 	['cog55'] = {
 		['name'] = 'Cognoscenti 55',
@@ -2024,7 +1801,6 @@ QBShared.Vehicles = {
 		['price'] = 22000,
 		['category'] = 'sedans',
 		['hash'] = `cog55`,
-		['shop'] = 'pdm',
 	},
 	['cognoscenti'] = {
 		['name'] = 'Cognoscenti',
@@ -2033,7 +1809,6 @@ QBShared.Vehicles = {
 		['price'] = 22500,
 		['category'] = 'sedans',
 		['hash'] = `cognoscenti`,
-		['shop'] = 'pdm',
 	},
 	['emperor'] = {
 		['name'] = 'Emperor',
@@ -2042,7 +1817,6 @@ QBShared.Vehicles = {
 		['price'] = 4250,
 		['category'] = 'sedans',
 		['hash'] = `emperor`,
-		['shop'] = 'pdm',
 	},
 	['fugitive'] = {
 		['name'] = 'Fugitive',
@@ -2051,7 +1825,6 @@ QBShared.Vehicles = {
 		['price'] = 20000,
 		['category'] = 'sedans',
 		['hash'] = `fugitive`,
-		['shop'] = 'pdm',
 	},
 	['glendale'] = {
 		['name'] = 'Glendale',
@@ -2060,7 +1833,6 @@ QBShared.Vehicles = {
 		['price'] = 3400,
 		['category'] = 'sedans',
 		['hash'] = `glendale`,
-		['shop'] = 'pdm',
 	},
 	['glendale2'] = {
 		['name'] = 'Glendale',
@@ -2069,7 +1841,6 @@ QBShared.Vehicles = {
 		['price'] = 12000,
 		['category'] = 'sedans',
 		['hash'] = `glendale2`,
-		['shop'] = 'pdm',
 	},
 	['ingot'] = {
 		['name'] = 'Ingot',
@@ -2078,7 +1849,6 @@ QBShared.Vehicles = {
 		['price'] = 4999,
 		['category'] = 'sedans',
 		['hash'] = `ingot`,
-		['shop'] = 'pdm',
 	},
 	['intruder'] = {
 		['name'] = 'Intruder',
@@ -2087,7 +1857,6 @@ QBShared.Vehicles = {
 		['price'] = 11250,
 		['category'] = 'sedans',
 		['hash'] = `intruder`,
-		['shop'] = 'pdm',
 	},
 	['premier'] = {
 		['name'] = 'Premier',
@@ -2096,7 +1865,6 @@ QBShared.Vehicles = {
 		['price'] = 12000,
 		['category'] = 'sedans',
 		['hash'] = `premier`,
-		['shop'] = 'pdm',
 	},
 	['primo'] = {
 		['name'] = 'Primo',
@@ -2105,7 +1873,6 @@ QBShared.Vehicles = {
 		['price'] = 5000,
 		['category'] = 'sedans',
 		['hash'] = `primo`,
-		['shop'] = 'pdm',
 	},
 	['primo2'] = {
 		['name'] = 'Primo Custom',
@@ -2114,7 +1881,6 @@ QBShared.Vehicles = {
 		['price'] = 14500,
 		['category'] = 'sedans',
 		['hash'] = `primo2`,
-		['shop'] = 'pdm',
 	},
 	['regina'] = {
 		['name'] = 'Regina',
@@ -2123,7 +1889,6 @@ QBShared.Vehicles = {
 		['price'] = 7000,
 		['category'] = 'sedans',
 		['hash'] = `regina`,
-		['shop'] = 'pdm',
 	},
 	['stafford'] = {							--DLC
 		['name'] = 'Stafford',
@@ -2132,7 +1897,6 @@ QBShared.Vehicles = {
 		['price'] = 30000,
 		['category'] = 'sedans',
 		['hash'] = `stafford`,
-		['shop'] = 'pdm',
 	},
 	['stanier'] = {
 		['name'] = 'Stanier',
@@ -2141,7 +1905,6 @@ QBShared.Vehicles = {
 		['price'] = 19000,
 		['category'] = 'sedans',
 		['hash'] = `stanier`,
-		['shop'] = 'pdm',
 	},
 	['stratum'] = {
 		['name'] = 'Stratum',
@@ -2150,7 +1913,6 @@ QBShared.Vehicles = {
 		['price'] = 15000,
 		['category'] = 'sedans',
 		['hash'] = `stratum`,
-		['shop'] = 'pdm',
 	},
 	['stretch'] = {
 		['name'] = 'Stretch',
@@ -2159,7 +1921,6 @@ QBShared.Vehicles = {
 		['price'] = 19000,
 		['category'] = 'sedans',
 		['hash'] = `stretch`,
-		['shop'] = 'pdm',
 	},
 	['superd'] = {
 		['name'] = 'Super Diamond',
@@ -2168,7 +1929,6 @@ QBShared.Vehicles = {
 		['price'] = 17000,
 		['category'] = 'sedans',
 		['hash'] = `superd`,
-		['shop'] = 'pdm',
 	},
 	['surge'] = {
 		['name'] = 'Surge',
@@ -2177,7 +1937,6 @@ QBShared.Vehicles = {
 		['price'] = 20000,
 		['category'] = 'sedans',
 		['hash'] = `surge`,
-		['shop'] = 'pdm',
 	},
 	['tailgater'] = {
 		['name'] = 'Tailgater',
@@ -2186,7 +1945,6 @@ QBShared.Vehicles = {
 		['price'] = 22000,
 		['category'] = 'sedans',
 		['hash'] = `tailgater`,
-		['shop'] = 'pdm',
 	},
 	['warrener'] = {
 		['name'] = 'Warrener',
@@ -2195,7 +1953,6 @@ QBShared.Vehicles = {
 		['price'] = 4000,
 		['category'] = 'sedans',
 		['hash'] = `warrener`,
-		['shop'] = 'pdm',
 	},
 	['washington'] = {
 		['name'] = 'Washington',
@@ -2204,7 +1961,6 @@ QBShared.Vehicles = {
 		['price'] = 7000,
 		['category'] = 'sedans',
 		['hash'] = `washington`,
-		['shop'] = 'pdm',
 	},
 	['tailgater2'] = {							--DLC +set sv_enforceGameBuild 2372
 		['name'] = 'Tailgater S',
@@ -2213,7 +1969,6 @@ QBShared.Vehicles = {
 		['price'] = 51000,
 		['category'] = 'sedans',
 		['hash'] = `tailgater2`,
-		['shop'] = 'pdm',
 	},
 	['cinquemila'] = { 	 	--DLC +set sv_enforceGameBuild 2545
 		['name'] = 'Lampadati',
@@ -2222,7 +1977,6 @@ QBShared.Vehicles = {
 		['price'] = 125000,
 		['category'] = 'sedans',
 		['hash'] = `cinquemila`,
-		['shop'] = 'pdm',
 	},
 	['iwagen'] = { 	 	--DLC +set sv_enforceGameBuild 2545
 		['name'] = 'Obey',
@@ -2231,7 +1985,6 @@ QBShared.Vehicles = {
 		['price'] = 225000,
 		['category'] = 'sedans',
 		['hash'] = `iwagen`,
-		['shop'] = 'pdm',
 	},
 	['astron'] = { 	 	--DLC +set sv_enforceGameBuild 2545
 		['name'] = 'Pfister',
@@ -2240,7 +1993,6 @@ QBShared.Vehicles = {
 		['price'] = 150000,
 		['category'] = 'sedans',
 		['hash'] = `astron`,
-		['shop'] = 'pdm',
 	},
 	['baller7'] = { 	 	--DLC +set sv_enforceGameBuild 2545
 		['name'] = 'Baller ST',
@@ -2249,7 +2001,6 @@ QBShared.Vehicles = {
 		['price'] = 145000,
 		['category'] = 'sedans',
 		['hash'] = `baller7`,
-		['shop'] = 'pdm',
 	},
 	['comet7'] = { 	 	--DLC +set sv_enforceGameBuild 2545
 		['name'] = 'Comet',
@@ -2258,7 +2009,6 @@ QBShared.Vehicles = {
 		['price'] = 25000,
 		['category'] = 'sedans',
 		['hash'] = `comet7`,
-		['shop'] = 'pdm',
 	},
 	['deity'] = { 	 	--DLC +set sv_enforceGameBuild 2545
 		['name'] = 'Deity',
@@ -2267,7 +2017,6 @@ QBShared.Vehicles = {
 		['price'] = 505000,
 		['category'] = 'sedans',
 		['hash'] = `deity`,
-		['shop'] = 'pdm',
 	},
 	['jubilee'] = { 	 	--DLC +set sv_enforceGameBuild 2545
 		['name'] = 'Jubilee',
@@ -2276,7 +2025,6 @@ QBShared.Vehicles = {
 		['price'] = 485000,
 		['category'] = 'sedans',
 		['hash'] = `jubilee`,
-		['shop'] = 'pdm',
 	},
 	['patriot3'] = { 	 	--DLC +set sv_enforceGameBuild 2545
 		['name'] = 'Patriot',
@@ -2285,7 +2033,6 @@ QBShared.Vehicles = {
 		['price'] = 270000,
 		['category'] = 'sedans',
 		['hash'] = `patriot3`,
-		['shop'] = 'pdm',
 	},
 	--- Sports
 	['alpha'] = {
@@ -2295,7 +2042,6 @@ QBShared.Vehicles = {
 		['price'] = 53000,
 		['category'] = 'sports',
 		['hash'] = `alpha`,
-		['shop'] = 'luxury',
 	},
 	['banshee'] = {
 		['name'] = 'Banshee',
@@ -2304,7 +2050,6 @@ QBShared.Vehicles = {
 		['price'] = 56000,
 		['category'] = 'sports',
 		['hash'] = `banshee`,
-		['shop'] = 'luxury',
 	},
 	['bestiagts'] = {
 		['name'] = 'Bestia GTS',
@@ -2313,7 +2058,6 @@ QBShared.Vehicles = {
 		['price'] = 37000,
 		['category'] = 'sports',
 		['hash'] = `bestiagts`,
-		['shop'] = 'luxury',
 	},
 	['blista2'] = {
 		['name'] = 'Blista Compact',
@@ -2322,7 +2066,6 @@ QBShared.Vehicles = {
 		['price'] = 18950,
 		['category'] = 'compacts',
 		['hash'] = `blista2`,
-		['shop'] = 'pdm',
 	},
 	['blista3'] = {
 		['name'] = 'Blista Go Go Monkey',
@@ -2331,7 +2074,6 @@ QBShared.Vehicles = {
 		['price'] = 15000,
 		['category'] = 'compacts',
 		['hash'] = `blista3`,
-		['shop'] = 'pdm',
 	},
 	['buffalo'] = {
 		['name'] = 'Buffalo',
@@ -2340,7 +2082,6 @@ QBShared.Vehicles = {
 		['price'] = 18750,
 		['category'] = 'sports',
 		['hash'] = `buffalo`,
-		['shop'] = 'luxury',
 	},
 	['buffalo2'] = {
 		['name'] = 'Buffalo S',
@@ -2349,7 +2090,6 @@ QBShared.Vehicles = {
 		['price'] = 24500,
 		['category'] = 'sports',
 		['hash'] = `buffalo2`,
-		['shop'] = 'luxury',
 	},
 	['carbonizzare'] = {
 		['name'] = 'Carbonizzare',
@@ -2358,7 +2098,6 @@ QBShared.Vehicles = {
 		['price'] = 155000,
 		['category'] = 'sports',
 		['hash'] = `carbonizzare`,
-		['shop'] = 'luxury',
 	},
 	['comet2'] = {
 		['name'] = 'Comet',
@@ -2367,7 +2106,6 @@ QBShared.Vehicles = {
 		['price'] = 130000,
 		['category'] = 'sports',
 		['hash'] = `comet2`,
-		['shop'] = 'luxury',
 	},
 	['comet3'] = {
 		['name'] = 'Comet Retro Custom',
@@ -2376,7 +2114,6 @@ QBShared.Vehicles = {
 		['price'] = 175000,
 		['category'] = 'sports',
 		['hash'] = `comet3`,
-		['shop'] = 'luxury',
 	},
 	['comet4'] = {
 		['name'] = 'Comet Safari',
@@ -2385,7 +2122,6 @@ QBShared.Vehicles = {
 		['price'] = 110000,
 		['category'] = 'sports',
 		['hash'] = `comet4`,
-		['shop'] = 'luxury',
 	},
 	['comet5'] = {
 		['name'] = 'Comet SR',
@@ -2394,7 +2130,6 @@ QBShared.Vehicles = {
 		['price'] = 155000,
 		['category'] = 'sports',
 		['hash'] = `comet5`,
-		['shop'] = 'luxury',
 	},
 	['coquette'] = {
 		['name'] = 'Coquette',
@@ -2403,7 +2138,6 @@ QBShared.Vehicles = {
 		['price'] = 145000,
 		['category'] = 'sports',
 		['hash'] = `coquette`,
-		['shop'] = 'luxury',
 	},
 	['coquette2'] = {
 		['name'] = 'Coquette Classic',
@@ -2412,7 +2146,6 @@ QBShared.Vehicles = {
 		['price'] = 165000,
 		['category'] = 'sportsclassics',
 		['hash'] = `coquette2`,
-		['shop'] = 'pdm',
 	},
 	['coquette4'] = {
 		['name'] = 'Coquette D10',
@@ -2421,7 +2154,6 @@ QBShared.Vehicles = {
 		['price'] = 220000,
 		['category'] = 'sports',
 		['hash'] = `coquette4`,
-		['shop'] = 'luxury',
 	},
 	['drafter'] = {							--DLC
 		['name'] = '8F Drafter',
@@ -2430,7 +2162,6 @@ QBShared.Vehicles = {
 		['price'] = 80000,
 		['category'] = 'sports',
 		['hash'] = `drafter`,
-		['shop'] = 'luxury',
 	},
 	['deveste'] = {							--DLC
 		['name'] = 'Deveste',
@@ -2439,7 +2170,6 @@ QBShared.Vehicles = {
 		['price'] = 234000,
 		['category'] = 'super',
 		['hash'] = `deveste`,
-		['shop'] = 'luxury',
 	},
 	['elegy'] = {							--DLC
 		['name'] = 'Elegy Retro Custom',
@@ -2448,7 +2178,6 @@ QBShared.Vehicles = {
 		['price'] = 145000,
 		['category'] = 'sports',
 		['hash'] = `elegy`,
-		['shop'] = 'luxury',
 	},
 	['elegy2'] = {
 		['name'] = 'Elegy RH8',
@@ -2457,7 +2186,6 @@ QBShared.Vehicles = {
 		['price'] = 150000,
 		['category'] = 'sports',
 		['hash'] = `elegy2`,
-		['shop'] = 'luxury',
 	},
 	['feltzer2'] = {
 		['name'] = 'Feltzer',
@@ -2466,7 +2194,6 @@ QBShared.Vehicles = {
 		['price'] = 97000,
 		['category'] = 'sports',
 		['hash'] = `feltzer2`,
-		['shop'] = 'luxury',
 	},
 	['flashgt'] = {
 		['name'] = 'Flash GT',
@@ -2475,7 +2202,6 @@ QBShared.Vehicles = {
 		['price'] = 48000,
 		['category'] = 'sports',
 		['hash'] = `flashgt`,
-		['shop'] = 'luxury',
 	},
 	['furoregt'] = {
 		['name'] = 'Furore GT',
@@ -2484,7 +2210,6 @@ QBShared.Vehicles = {
 		['price'] = 78000,
 		['category'] = 'sports',
 		['hash'] = `furoregt`,
-		['shop'] = 'luxury',
 	},
 	['futo'] = {
 		['name'] = 'Futo',
@@ -2493,7 +2218,6 @@ QBShared.Vehicles = {
 		['price'] = 17500,
 		['category'] = 'coupes',
 		['hash'] = `futo`,
-		['shop'] = 'pdm',
 	},
 	['gb200'] = {
 		['name'] = 'GB 200',
@@ -2502,7 +2226,6 @@ QBShared.Vehicles = {
 		['price'] = 140000,
 		['category'] = 'sports',
 		['hash'] = `gb200`,
-		['shop'] = 'luxury',
 	},
 	['komoda'] = {
 		['name'] = 'Komoda',
@@ -2511,7 +2234,6 @@ QBShared.Vehicles = {
 		['price'] = 55000,
 		['category'] = 'sports',
 		['hash'] = `komoda`,
-		['shop'] = 'luxury',
 	},
 	['imorgon'] = {
 		['name'] = 'Imorgon',
@@ -2520,7 +2242,6 @@ QBShared.Vehicles = {
 		['price'] = 120000,
 		['category'] = 'sports',
 		['hash'] = `imorgon`,
-		['shop'] = 'luxury',
 	},
 	['issi7'] = {							--DLC
 		['name'] = 'Issi Sport',
@@ -2529,7 +2250,6 @@ QBShared.Vehicles = {
 		['price'] = 100000,
 		['category'] = 'compacts',
 		['hash'] = `issi7`,
-		['shop'] = 'pdm',
 	},
 	['italigto'] = {							--DLC
 		['name'] = 'Itali GTO',
@@ -2538,7 +2258,6 @@ QBShared.Vehicles = {
 		['price'] = 260000,
 		['category'] = 'sports',
 		['hash'] = `italigto`,
-		['shop'] = 'luxury',
 	},
 	['jugular'] = {							--DLC
 		['name'] = 'Jugular',
@@ -2547,7 +2266,6 @@ QBShared.Vehicles = {
 		['price'] = 80000,
 		['category'] = 'sports',
 		['hash'] = `jugular`,
-		['shop'] = 'luxury',
 	},
 	['jester'] = {
 		['name'] = 'Jester',
@@ -2556,7 +2274,6 @@ QBShared.Vehicles = {
 		['price'] = 132250,
 		['category'] = 'sports',
 		['hash'] = `jester`,
-		['shop'] = 'luxury',
 	},
 	['jester2'] = {
 		['name'] = 'Jester Racecar',
@@ -2565,7 +2282,6 @@ QBShared.Vehicles = {
 		['price'] = 210000,
 		['category'] = 'sports',
 		['hash'] = `jester2`,
-		['shop'] = 'luxury',
 	},
 	['jester3'] = {
 		['name'] = 'Jester Classic',
@@ -2574,7 +2290,6 @@ QBShared.Vehicles = {
 		['price'] = 85000,
 		['category'] = 'sports',
 		['hash'] = `jester3`,
-		['shop'] = 'luxury',
 	},
 	['khamelion'] = {
 		['name'] = 'Khamelion',
@@ -2583,7 +2298,6 @@ QBShared.Vehicles = {
 		['price'] = 90000,
 		['category'] = 'sports',
 		['hash'] = `khamelion`,
-		['shop'] = 'luxury',
 	},
 	['kuruma'] = {
 		['name'] = 'Kuruma',
@@ -2592,7 +2306,6 @@ QBShared.Vehicles = {
 		['price'] = 72000,
 		['category'] = 'sports',
 		['hash'] = `kuruma`,
-		['shop'] = 'luxury',
 	},
 	['kuruma2'] = {
 		['name'] = 'kuruma2',
@@ -2601,7 +2314,6 @@ QBShared.Vehicles = {
 		['price'] = 72000,
 		['category'] = 'sports',
 		['hash'] = `kuruma2`,
-		['shop'] = 'luxury',
 	},
 	['locust'] = {							--DLC
 		['name'] = 'Locust',
@@ -2610,7 +2322,6 @@ QBShared.Vehicles = {
 		['price'] = 200000,
 		['category'] = 'sports',
 		['hash'] = `locust`,
-		['shop'] = 'luxury',
 	},
 	['lynx'] = {
 		['name'] = 'Lynx',
@@ -2619,7 +2330,6 @@ QBShared.Vehicles = {
 		['price'] = 150000,
 		['category'] = 'sports',
 		['hash'] = `lynx`,
-		['shop'] = 'luxury',
 	},
 	['massacro'] = {
 		['name'] = 'Massacro',
@@ -2628,7 +2338,6 @@ QBShared.Vehicles = {
 		['price'] = 110000,
 		['category'] = 'sports',
 		['hash'] = `massacro`,
-		['shop'] = 'luxury',
 	},
 	['massacro2'] = {
 		['name'] = 'Massacro Racecar',
@@ -2637,7 +2346,6 @@ QBShared.Vehicles = {
 		['price'] = 80000,
 		['category'] = 'sports',
 		['hash'] = `massacro2`,
-		['shop'] = 'luxury',
 	},
 	['neo'] = {							--DLC
 		['name'] = 'Neo',
@@ -2646,7 +2354,6 @@ QBShared.Vehicles = {
 		['price'] = 230000,
 		['category'] = 'sports',
 		['hash'] = `neo`,
-		['shop'] = 'luxury',
 	},
 	['neon'] = {							--DLC
 		['name'] = 'Neon',
@@ -2655,7 +2362,6 @@ QBShared.Vehicles = {
 		['price'] = 220000,
 		['category'] = 'sports',
 		['hash'] = `neon`,
-		['shop'] = 'luxury',
 	},
 	['ninef'] = {
 		['name'] = '9F',
@@ -2664,7 +2370,6 @@ QBShared.Vehicles = {
 		['price'] = 95000,
 		['category'] = 'sports',
 		['hash'] = `ninef`,
-		['shop'] = 'luxury',
 	},
 	['ninef2'] = {
 		['name'] = '9F Cabrio',
@@ -2673,7 +2378,6 @@ QBShared.Vehicles = {
 		['price'] = 105000,
 		['category'] = 'sports',
 		['hash'] = `ninef2`,
-		['shop'] = 'luxury',
 	},
 	['omnis'] = {
 		['name'] = 'Omnis',
@@ -2682,7 +2386,6 @@ QBShared.Vehicles = {
 		['price'] = 90000,
 		['category'] = 'sports',
 		['hash'] = `omnis`,
-		['shop'] = 'luxury',
 	},
 	['paragon'] = {							--DLC
 		['name'] = 'Paragon',
@@ -2691,7 +2394,6 @@ QBShared.Vehicles = {
 		['price'] = 60000,
 		['category'] = 'sports',
 		['hash'] = `paragon`,
-		['shop'] = 'luxury',
 	},
 	['pariah'] = {
 		['name'] = 'Pariah',
@@ -2700,7 +2402,6 @@ QBShared.Vehicles = {
 		['price'] = 90000,
 		['category'] = 'sports',
 		['hash'] = `pariah`,
-		['shop'] = 'luxury',
 	},
 	['penumbra'] = {
 		['name'] = 'Penumbra',
@@ -2709,7 +2410,6 @@ QBShared.Vehicles = {
 		['price'] = 22000,
 		['category'] = 'sports',
 		['hash'] = `penumbra`,
-		['shop'] = 'luxury',
 	},
 	['penumbra2'] = {
 		['name'] = 'Penumbra FF',
@@ -2718,7 +2418,6 @@ QBShared.Vehicles = {
 		['price'] = 30000,
 		['category'] = 'sports',
 		['hash'] = `penumbra2`,
-		['shop'] = 'luxury',
 	},
 	['rapidgt'] = {
 		['name'] = 'Rapid GT',
@@ -2727,7 +2426,6 @@ QBShared.Vehicles = {
 		['price'] = 86000,
 		['category'] = 'sports',
 		['hash'] = `rapidgt`,
-		['shop'] = 'luxury',
 	},
 	['rapidgt2'] = {
 		['name'] = 'Rapid GT Convertible',
@@ -2736,7 +2434,6 @@ QBShared.Vehicles = {
 		['price'] = 92000,
 		['category'] = 'sports',
 		['hash'] = `rapidgt2`,
-		['shop'] = 'luxury',
 	},
 	['raptor'] = {
 		['name'] = 'Raptor',
@@ -2745,7 +2442,6 @@ QBShared.Vehicles = {
 		['price'] = 90000,
 		['category'] = 'sports',
 		['hash'] = `raptor`,
-		['shop'] = 'luxury',
 	},
 	['revolter'] = {
 		['name'] = 'Revolter',
@@ -2754,7 +2450,6 @@ QBShared.Vehicles = {
 		['price'] = 95000,
 		['category'] = 'sports',
 		['hash'] = `revolter`,
-		['shop'] = 'luxury',
 	},
 	['ruston'] = {
 		['name'] = 'Ruston',
@@ -2763,7 +2458,6 @@ QBShared.Vehicles = {
 		['price'] = 130000,
 		['category'] = 'sports',
 		['hash'] = `ruston`,
-		['shop'] = 'luxury',
 	},
 	['schafter2'] = {
 		['name'] = 'Schafter',
@@ -2772,7 +2466,6 @@ QBShared.Vehicles = {
 		['price'] = 16000,
 		['category'] = 'sedans',
 		['hash'] = `schafter2`,
-		['shop'] = 'pdm',
 	},
 	['schafter3'] = {
 		['name'] = 'Schafter V12',
@@ -2781,7 +2474,6 @@ QBShared.Vehicles = {
 		['price'] = 35000,
 		['category'] = 'sports',
 		['hash'] = `schafter3`,
-		['shop'] = 'luxury',
 	},
 	['schafter4'] = {
 		['name'] = 'Schafter LWB',
@@ -2790,7 +2482,6 @@ QBShared.Vehicles = {
 		['price'] = 21000,
 		['category'] = 'sports',
 		['hash'] = `schafter4`,
-		['shop'] = 'luxury',
 	},
 	['schlagen'] = {							--DLC
 		['name'] = 'Schlagen GT',
@@ -2799,7 +2490,6 @@ QBShared.Vehicles = {
 		['price'] = 160000,
 		['category'] = 'sports',
 		['hash'] = `schlagen`,
-		['shop'] = 'luxury',
 	},
 	['schwarzer'] = {
 		['name'] = 'Schwartzer',
@@ -2808,7 +2498,6 @@ QBShared.Vehicles = {
 		['price'] = 47000,
 		['category'] = 'sports',
 		['hash'] = `schwarzer`,
-		['shop'] = 'luxury',
 	},
 	['sentinel3'] = {
 		['name'] = 'Sentinel Classic',
@@ -2817,7 +2506,6 @@ QBShared.Vehicles = {
 		['price'] = 70000,
 		['category'] = 'coupes',
 		['hash'] = `sentinel3`,
-		['shop'] = 'pdm',
 	},
 	['seven70'] = {
 		['name'] = 'Seven-70',
@@ -2826,7 +2514,6 @@ QBShared.Vehicles = {
 		['price'] = 140000,
 		['category'] = 'sports',
 		['hash'] = `seven70`,
-		['shop'] = 'luxury',
 	},
 	['specter'] = {
 		['name'] = 'Specter',
@@ -2835,7 +2522,6 @@ QBShared.Vehicles = {
 		['price'] = 160000,
 		['category'] = 'sports',
 		['hash'] = `specter`,
-		['shop'] = 'luxury',
 	},
 	['streiter'] = {
 		['name'] = 'Streiter',
@@ -2844,7 +2530,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'sports',
 		['hash'] = `streiter`,
-		['shop'] = 'luxury',
 	},
 	['sugoi'] = {
 		['name'] = 'Sugoi',
@@ -2853,7 +2538,6 @@ QBShared.Vehicles = {
 		['price'] = 85000,
 		['category'] = 'sports',
 		['hash'] = `sugoi`,
-		['shop'] = 'luxury',
 	},
 	['sultan'] = {
 		['name'] = 'Sultan',
@@ -2862,7 +2546,6 @@ QBShared.Vehicles = {
 		['price'] = 50000,
 		['category'] = 'sports',
 		['hash'] = `sultan`,
-		['shop'] = 'luxury',
 	},
 	['sultan2'] = {
 		['name'] = 'Sultan Custom',
@@ -2871,7 +2554,6 @@ QBShared.Vehicles = {
 		['price'] = 55000,
 		['category'] = 'sports',
 		['hash'] = `sultan2`,
-		['shop'] = 'luxury',
 	},
 	['surano'] = {
 		['name'] = 'Surano',
@@ -2880,7 +2562,6 @@ QBShared.Vehicles = {
 		['price'] = 80000,
 		['category'] = 'sports',
 		['hash'] = `surano`,
-		['shop'] = 'luxury',
 	},
 	['tampa2'] = {
 		['name'] = 'Drift Tampa',
@@ -2889,7 +2570,6 @@ QBShared.Vehicles = {
 		['price'] = 80000,
 		['category'] = 'muscle',
 		['hash'] = `tampa2`,
-		['shop'] = 'pdm',
 	},
 	['tropos'] = {
 		['name'] = 'Tropos Rallye',
@@ -2898,7 +2578,6 @@ QBShared.Vehicles = {
 		['price'] = 65000,
 		['category'] = 'sports',
 		['hash'] = `tropos`,
-		['shop'] = 'luxury',
 	},
 	['verlierer2'] = {
 		['name'] = 'Verlierer',
@@ -2907,7 +2586,6 @@ QBShared.Vehicles = {
 		['price'] = 90500,
 		['category'] = 'sports',
 		['hash'] = `verlierer2`,
-		['shop'] = 'luxury',
 	},
 	['vstr'] = {
 		['name'] = 'V-STR',
@@ -2916,7 +2594,6 @@ QBShared.Vehicles = {
 		['price'] = 80000,
 		['category'] = 'sports',
 		['hash'] = `vstr`,
-		['shop'] = 'luxury',
 	},
 	['italirsx'] = {
 		['name'] = 'Itali RSX',
@@ -2925,7 +2602,6 @@ QBShared.Vehicles = {
 		['price'] = 260000,
 		['category'] = 'sports',
 		['hash'] = `italirsx`,
-		['shop'] = 'luxury',
 	},
 	['zr350'] = {							--DLC +set sv_enforceGameBuild 2372
 		['name'] = 'ZR350',
@@ -2934,7 +2610,6 @@ QBShared.Vehicles = {
 		['price'] = 38000,
 		['category'] = 'sports',
 		['hash'] = `zr350`,
-		['shop'] = 'luxury',
 	},
 	['calico'] = {							--DLC +set sv_enforceGameBuild 2372
 		['name'] = 'Calico GTF',
@@ -2943,7 +2618,6 @@ QBShared.Vehicles = {
 		['price'] = 39000,
 		['category'] = 'sports',
 		['hash'] = `calico`,
-		['shop'] = 'luxury',
 	},
 	['futo2'] = {							--DLC +set sv_enforceGameBuild 2372
 		['name'] = 'Futo GTX',
@@ -2952,7 +2626,6 @@ QBShared.Vehicles = {
 		['price'] = 39000,
 		['category'] = 'sports',
 		['hash'] = `futo2`,
-		['shop'] = 'luxury',
 	},
 	['euros'] = {							--DLC +set sv_enforceGameBuild 2372
 		['name'] = 'Euros',
@@ -2961,7 +2634,6 @@ QBShared.Vehicles = {
 		['price'] = 80000,
 		['category'] = 'sports',
 		['hash'] = `euros`,
-		['shop'] = 'luxury',
 	},
 	['jester4'] = {							--DLC +set sv_enforceGameBuild 2372
 		['name'] = 'Jester RR',
@@ -2970,7 +2642,6 @@ QBShared.Vehicles = {
 		['price'] = 240000,
 		['category'] = 'sports',
 		['hash'] = `jester4`,
-		['shop'] = 'luxury',
 	},
 	['remus'] = {							--DLC +set sv_enforceGameBuild 2372
 		['name'] = 'Remus',
@@ -2979,7 +2650,6 @@ QBShared.Vehicles = {
 		['price'] = 48000,
 		['category'] = 'sports',
 		['hash'] = `remus`,
-		['shop'] = 'luxury',
 	},
 	['comet6'] = {							--DLC +set sv_enforceGameBuild 2372
 		['name'] = 'Comet S2',
@@ -2988,7 +2658,6 @@ QBShared.Vehicles = {
 		['price'] = 230000,
 		['category'] = 'sports',
 		['hash'] = `comet6`,
-		['shop'] = 'luxury',
 	},
 	['growler'] = {							--DLC +set sv_enforceGameBuild 2372
 		['name'] = 'Growler',
@@ -2997,7 +2666,6 @@ QBShared.Vehicles = {
 		['price'] = 205000,
 		['category'] = 'sports',
 		['hash'] = `growler`,
-		['shop'] = 'luxury',
 	},
 	['vectre'] = {							--DLC +set sv_enforceGameBuild 2372
 		['name'] = 'Emperor Vectre',
@@ -3006,7 +2674,6 @@ QBShared.Vehicles = {
 		['price'] = 80000,
 		['category'] = 'sports',
 		['hash'] = `vectre`,
-		['shop'] = 'luxury',
 	},
 	['cypher'] = {							--DLC +set sv_enforceGameBuild 2372
 		['name'] = 'Cypher',
@@ -3015,7 +2682,6 @@ QBShared.Vehicles = {
 		['price'] = 155000,
 		['category'] = 'sports',
 		['hash'] = `cypher`,
-		['shop'] = 'luxury',
 	},
 	['sultan3'] = {							--DLC +set sv_enforceGameBuild 2372
 		['name'] = 'Sultan Classic Custom',
@@ -3024,7 +2690,6 @@ QBShared.Vehicles = {
 		['price'] = 56000,
 		['category'] = 'sports',
 		['hash'] = `sultan3`,
-		['shop'] = 'luxury',
 	},
 	['rt3000'] = {							--DLC +set sv_enforceGameBuild 2372
 		['name'] = 'RT3000',
@@ -3033,7 +2698,6 @@ QBShared.Vehicles = {
 		['price'] = 65000,
 		['category'] = 'sports',
 		['hash'] = `rt3000`,
-		['shop'] = 'luxury',
 	},
 	--- Sports Classic
 	['ardent'] = {
@@ -3043,7 +2707,6 @@ QBShared.Vehicles = {
 		['price'] = 30000,
 		['category'] = 'sportsclassics',
 		['hash'] = `ardent`,
-		['shop'] = 'pdm',
 	},
 	['btype'] = {              --meme car that goes pretty fast
 		['name'] = 'Roosevelt',
@@ -3052,7 +2715,6 @@ QBShared.Vehicles = {
 		['price'] = 75000,
 		['category'] = 'sportsclassics',
 		['hash'] = `btype`,
-		['shop'] = 'pdm',
 	},
 	['btype2'] = {
 		['name'] = 'Franken Stange',
@@ -3061,7 +2723,6 @@ QBShared.Vehicles = {
 		['price'] = 87000,
 		['category'] = 'sportsclassics',
 		['hash'] = `btype2`,
-		['shop'] = 'pdm',
 	},
 	['btype3'] = {
 		['name'] = 'Roosevelt Valor',
@@ -3070,7 +2731,6 @@ QBShared.Vehicles = {
 		['price'] = 63000,
 		['category'] = 'sportsclassics',
 		['hash'] = `btype3`,
-		['shop'] = 'pdm',
 	},
 	['casco'] = {
 		['name'] = 'Casco',
@@ -3079,7 +2739,6 @@ QBShared.Vehicles = {
 		['price'] = 100000,
 		['category'] = 'sportsclassics',
 		['hash'] = `casco`,
-		['shop'] = 'pdm',
 	},
 	['cheetah2'] = {
 		['name'] = 'Cheetah Classic',
@@ -3088,7 +2747,6 @@ QBShared.Vehicles = {
 		['price'] = 195000,
 		['category'] = 'sports',
 		['hash'] = `cheetah2`,
-		['shop'] = 'luxury',
 	},
 	['deluxo'] = {
 		['name'] = 'Deluxo',
@@ -3097,7 +2755,6 @@ QBShared.Vehicles = {
 		['price'] = 55000,
 		['category'] = 'sportsclassics',
 		['hash'] = `deluxo`,
-		['shop'] = 'pdm',
 	},
 	['dynasty'] = {							--DLC
 		['name'] = 'Dynasty',
@@ -3106,7 +2763,6 @@ QBShared.Vehicles = {
 		['price'] = 25000,
 		['category'] = 'sportsclassics',
 		['hash'] = `dynasty`,
-		['shop'] = 'pdm',
 	},
 	['fagaloa'] = {
 		['name'] = 'Fagaloa',
@@ -3115,7 +2771,6 @@ QBShared.Vehicles = {
 		['price'] = 13000,
 		['category'] = 'sportsclassics',
 		['hash'] = `fagaloa`,
-		['shop'] = 'pdm',
 	},
 	['feltzer3'] = {							--DLC
 		['name'] = 'Stirling GT',
@@ -3124,7 +2779,6 @@ QBShared.Vehicles = {
 		['price'] = 115000,
 		['category'] = 'sportsclassics',
 		['hash'] = `feltzer3`,
-		['shop'] = 'pdm',
 	},
 	['gt500'] = {
 		['name'] = 'GT500',
@@ -3133,7 +2787,6 @@ QBShared.Vehicles = {
 		['price'] = 130000,
 		['category'] = 'sportsclassics',
 		['hash'] = `gt500`,
-		['shop'] = 'pdm',
 	},
 	['infernus2'] = {
 		['name'] = 'Infernus Classic',
@@ -3142,7 +2795,6 @@ QBShared.Vehicles = {
 		['price'] = 245000,
 		['category'] = 'sportsclassics',
 		['hash'] = `infernus2`,
-		['shop'] = 'pdm',
 	},
 	['jb700'] = {
 		['name'] = 'JB 700',
@@ -3151,7 +2803,6 @@ QBShared.Vehicles = {
 		['price'] = 240000,
 		['category'] = 'sportsclassics',
 		['hash'] = `jb700`,
-		['shop'] = 'pdm',
 	},
 	['jb7002'] = {
 		['name'] = 'JB 700W',
@@ -3160,7 +2811,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'sportsclassics',
 		['hash'] = `jb7002`,
-		['shop'] = 'pdm',
 	},
 	['mamba'] = {
 		['name'] = 'Mamba',
@@ -3169,7 +2819,6 @@ QBShared.Vehicles = {
 		['price'] = 140000,
 		['category'] = 'sportsclassics',
 		['hash'] = `mamba`,
-		['shop'] = 'pdm',
 	},
 	['manana'] = {
 		['name'] = 'Manana',
@@ -3178,7 +2827,6 @@ QBShared.Vehicles = {
 		['price'] = 12800,
 		['category'] = 'muscle',
 		['hash'] = `manana`,
-		['shop'] = 'pdm',
 	},
 	['manana2'] = {
 		['name'] = 'Manana Custom',
@@ -3187,7 +2835,6 @@ QBShared.Vehicles = {
 		['price'] = 24000,
 		['category'] = 'muscle',
 		['hash'] = `manana2`,
-		['shop'] = 'pdm',
 	},
 	['michelli'] = {
 		['name'] = 'Michelli GT',
@@ -3196,7 +2843,6 @@ QBShared.Vehicles = {
 		['price'] = 30000,
 		['category'] = 'sportsclassics',
 		['hash'] = `michelli`,
-		['shop'] = 'pdm',
 	},
 	['monroe'] = {
 		['name'] = 'Monroe',
@@ -3205,7 +2851,6 @@ QBShared.Vehicles = {
 		['price'] = 115000,
 		['category'] = 'sportsclassics',
 		['hash'] = `monroe`,
-		['shop'] = 'pdm',
 	},
 	['nebula'] = {							--DLC
 		['name'] = 'Nebula',
@@ -3214,7 +2859,6 @@ QBShared.Vehicles = {
 		['price'] = 22000,
 		['category'] = 'sportsclassics',
 		['hash'] = `nebula`,
-		['shop'] = 'pdm',
 	},
 	['peyote'] = {
 		['name'] = 'Peyote',
@@ -3223,7 +2867,6 @@ QBShared.Vehicles = {
 		['price'] = 23500,
 		['category'] = 'sportsclassics',
 		['hash'] = `peyote`,
-		['shop'] = 'pdm',
 	},
 	['peyote3'] = {
 		['name'] = 'Peyote Custom',
@@ -3232,7 +2875,6 @@ QBShared.Vehicles = {
 		['price'] = 48000,
 		['category'] = 'sportsclassics',
 		['hash'] = `peyote3`,
-		['shop'] = 'pdm',
 	},
 	['pigalle'] = {
 		['name'] = 'Pigalle',
@@ -3241,7 +2883,6 @@ QBShared.Vehicles = {
 		['price'] = 92000,
 		['category'] = 'sportsclassics',
 		['hash'] = `pigalle`,
-		['shop'] = 'pdm',
 	},
 	['rapidgt3'] = {
 		['name'] = 'Rapid GT',
@@ -3250,7 +2891,6 @@ QBShared.Vehicles = {
 		['price'] = 90000,
 		['category'] = 'sportsclassics',
 		['hash'] = `rapidgt3`,
-		['shop'] = 'pdm',
 	},
 	['retinue'] = {
 		['name'] = 'Retinue',
@@ -3259,7 +2899,6 @@ QBShared.Vehicles = {
 		['price'] = 32000,
 		['category'] = 'sportsclassics',
 		['hash'] = `retinue`,
-		['shop'] = 'pdm',
 	},
 	['retinue2'] = {
 		['name'] = 'Retinue MKII',
@@ -3268,7 +2907,6 @@ QBShared.Vehicles = {
 		['price'] = 38000,
 		['category'] = 'sportsclassics',
 		['hash'] = `retinue2`,
-		['shop'] = 'pdm',
 	},
 	['savestra'] = {
 		['name'] = 'Savestra',
@@ -3277,7 +2915,6 @@ QBShared.Vehicles = {
 		['price'] = 67000,
 		['category'] = 'sportsclassics',
 		['hash'] = `savestra`,
-		['shop'] = 'pdm',
 	},
 	['stinger'] = {
 		['name'] = 'Stinger',
@@ -3286,7 +2923,6 @@ QBShared.Vehicles = {
 		['price'] = 39500,
 		['category'] = 'sportsclassics',
 		['hash'] = `stinger`,
-		['shop'] = 'pdm',
 	},
 	['stingergt'] = {
 		['name'] = 'Stinger GT',
@@ -3295,7 +2931,6 @@ QBShared.Vehicles = {
 		['price'] = 70000,
 		['category'] = 'sportsclassics',
 		['hash'] = `stingergt`,
-		['shop'] = 'pdm',
 	},
 	['stromberg'] = {
 		['name'] = 'Stromberg',
@@ -3304,7 +2939,6 @@ QBShared.Vehicles = {
 		['price'] = 80000,
 		['category'] = 'sportsclassics',
 		['hash'] = `stromberg`,
-		['shop'] = 'pdm',
 	},
 	['swinger'] = {							--DLC
 		['name'] = 'Swinger',
@@ -3313,7 +2947,6 @@ QBShared.Vehicles = {
 		['price'] = 221000,
 		['category'] = 'sportsclassics',
 		['hash'] = `swinger`,
-		['shop'] = 'pdm',
 	},
 	['torero'] = {
 		['name'] = 'Torero',
@@ -3322,7 +2955,6 @@ QBShared.Vehicles = {
 		['price'] = 84000,
 		['category'] = 'sportsclassics',
 		['hash'] = `torero`,
-		['shop'] = 'pdm',
 	},
 	['tornado'] = {
 		['name'] = 'Tornado',
@@ -3331,7 +2963,6 @@ QBShared.Vehicles = {
 		['price'] = 21000,
 		['category'] = 'sportsclassics',
 		['hash'] = `tornado`,
-		['shop'] = 'pdm',
 	},
 	['tornado2'] = {
 		['name'] = 'Tornado Gang',
@@ -3340,7 +2971,6 @@ QBShared.Vehicles = {
 		['price'] = 22000,
 		['category'] = 'sportsclassics',
 		['hash'] = `tornado2`,
-		['shop'] = 'pdm',
 	},
 	['tornado5'] = {
 		['name'] = 'Tornado Custom',
@@ -3349,7 +2979,6 @@ QBShared.Vehicles = {
 		['price'] = 22000,
 		['category'] = 'sportsclassics',
 		['hash'] = `tornado5`,
-		['shop'] = 'pdm',
 	},
 	['turismo2'] = {
 		['name'] = 'Turismo Classic',
@@ -3358,7 +2987,6 @@ QBShared.Vehicles = {
 		['price'] = 170000,
 		['category'] = 'sportsclassics',
 		['hash'] = `turismo2`,
-		['shop'] = 'pdm',
 	},
 	['viseris'] = {
 		['name'] = 'Viseris',
@@ -3367,7 +2995,6 @@ QBShared.Vehicles = {
 		['price'] = 210000,
 		['category'] = 'sportsclassics',
 		['hash'] = `viseris`,
-		['shop'] = 'pdm',
 	},
 	['z190'] = {
 		['name'] = '190Z',
@@ -3376,7 +3003,6 @@ QBShared.Vehicles = {
 		['price'] = 78000,
 		['category'] = 'sportsclassics',
 		['hash'] = `z190`,
-		['shop'] = 'pdm',
 	},
 	['ztype'] = {
 		['name'] = 'Z-Type',
@@ -3385,7 +3011,6 @@ QBShared.Vehicles = {
 		['price'] = 270000,
 		['category'] = 'sportsclassics',
 		['hash'] = `ztype`,
-		['shop'] = 'pdm',
 	},
 	['zion3'] = {							--DLC
 		['name'] = 'Zion Classic',
@@ -3394,7 +3019,6 @@ QBShared.Vehicles = {
 		['price'] = 45000,
 		['category'] = 'sportsclassics',
 		['hash'] = `zion3`,
-		['shop'] = 'pdm',
 	},
 	['cheburek'] = {
 		['name'] = 'Cheburek',
@@ -3403,7 +3027,6 @@ QBShared.Vehicles = {
 		['price'] = 7000,
 		['category'] = 'sportsclassics',
 		['hash'] = `cheburek`,
-		['shop'] = 'pdm',
 	},
 	['toreador'] = {
 		['name'] = 'Toreador',
@@ -3412,7 +3035,6 @@ QBShared.Vehicles = {
 		['price'] = 50000,
 		['category'] = 'sportsclassics',
 		['hash'] = `toreador`,
-		['shop'] = 'pdm',
 	},
 	--- Super
 	['adder'] = {
@@ -3422,7 +3044,6 @@ QBShared.Vehicles = {
 		['price'] = 280000,
 		['category'] = 'super',
 		['hash'] = `adder`,
-		['shop'] = 'luxury',
 	},
 	['autarch'] = {
 		['name'] = 'Autarch',
@@ -3431,7 +3052,6 @@ QBShared.Vehicles = {
 		['price'] = 224000,
 		['category'] = 'super',
 		['hash'] = `autarch`,
-		['shop'] = 'luxury',
 	},
 	['banshee2'] = {
 		['name'] = 'Banshee 900R',
@@ -3440,7 +3060,6 @@ QBShared.Vehicles = {
 		['price'] = 120000,
 		['category'] = 'super',
 		['hash'] = `banshee2`,
-		['shop'] = 'luxury',
 	},
 	['bullet'] = {
 		['name'] = 'Bullet',
@@ -3449,7 +3068,6 @@ QBShared.Vehicles = {
 		['price'] = 120000,
 		['category'] = 'super',
 		['hash'] = `bullet`,
-		['shop'] = 'luxury',
 	},
 	['cheetah'] = {
 		['name'] = 'Cheetah',
@@ -3458,7 +3076,6 @@ QBShared.Vehicles = {
 		['price'] = 214000,
 		['category'] = 'super',
 		['hash'] = `cheetah`,
-		['shop'] = 'luxury',
 	},
 	['cyclone'] = {         --might be too overpowered
 		['name'] = 'Cyclone',
@@ -3467,7 +3084,6 @@ QBShared.Vehicles = {
 		['price'] = 300000,
 		['category'] = 'super',
 		['hash'] = `cyclone`,
-		['shop'] = 'luxury',
 	},
 	['entity2'] = {
 		['name'] = 'Entity XXR',
@@ -3476,7 +3092,6 @@ QBShared.Vehicles = {
 		['price'] = 164000,
 		['category'] = 'super',
 		['hash'] = `entity2`,
-		['shop'] = 'luxury',
 	},
 	['entityxf'] = {
 		['name'] = 'Entity XF',
@@ -3485,7 +3100,6 @@ QBShared.Vehicles = {
 		['price'] = 180000,
 		['category'] = 'super',
 		['hash'] = `entityxf`,
-		['shop'] = 'luxury',
 	},
 	['emerus'] = {							--DLC
 		['name'] = 'Emerus',
@@ -3494,7 +3108,6 @@ QBShared.Vehicles = {
 		['price'] = 220000,
 		['category'] = 'super',
 		['hash'] = `emerus`,
-		['shop'] = 'luxury',
 	},
 	['fmj'] = {
 		['name'] = 'FMJ',
@@ -3503,7 +3116,6 @@ QBShared.Vehicles = {
 		['price'] = 125000,
 		['category'] = 'super',
 		['hash'] = `fmj`,
-		['shop'] = 'luxury',
 	},
 	['furia'] = {
 		['name'] = 'Furia',
@@ -3512,7 +3124,6 @@ QBShared.Vehicles = {
 		['price'] = 230000,
 		['category'] = 'super',
 		['hash'] = `furia`,
-		['shop'] = 'luxury',
 	},
 	['gp1'] = {
 		['name'] = 'GP1',
@@ -3521,7 +3132,6 @@ QBShared.Vehicles = {
 		['price'] = 110000,
 		['category'] = 'super',
 		['hash'] = `gp1`,
-		['shop'] = 'luxury',
 	},
 	['infernus'] = {
 		['name'] = 'Infernus',
@@ -3530,7 +3140,6 @@ QBShared.Vehicles = {
 		['price'] = 235000,
 		['category'] = 'super',
 		['hash'] = `infernus`,
-		['shop'] = 'luxury',
 	},
 	['italigtb'] = {
 		['name'] = 'Itali GTB',
@@ -3539,7 +3148,6 @@ QBShared.Vehicles = {
 		['price'] = 170000,
 		['category'] = 'super',
 		['hash'] = `italigtb`,
-		['shop'] = 'luxury',
 	},
 	['italigtb2'] = {
 		['name'] = 'Itali GTB',
@@ -3548,7 +3156,6 @@ QBShared.Vehicles = {
 		['price'] = 250000,
 		['category'] = 'super',
 		['hash'] = `italigtb2`,
-		['shop'] = 'luxury',
 	},
 	['krieger'] = {							--DLC
 		['name'] = 'Krieger',
@@ -3557,7 +3164,6 @@ QBShared.Vehicles = {
 		['price'] = 222000,
 		['category'] = 'super',
 		['hash'] = `krieger`,
-		['shop'] = 'luxury',
 	},
 	['le7b'] = {
 		['name'] = 'RE-7B',
@@ -3566,7 +3172,6 @@ QBShared.Vehicles = {
 		['price'] = 260000,
 		['category'] = 'super',
 		['hash'] = `le7b`,
-		['shop'] = 'luxury',
 	},
 	['nero'] = {
 		['name'] = 'Nero',
@@ -3575,7 +3180,6 @@ QBShared.Vehicles = {
 		['price'] = 200000,
 		['category'] = 'super',
 		['hash'] = `nero`,
-		['shop'] = 'luxury',
 	},
 	['nero2'] = {
 		['name'] = 'Nero Custom',
@@ -3584,7 +3188,6 @@ QBShared.Vehicles = {
 		['price'] = 260000,
 		['category'] = 'super',
 		['hash'] = `nero2`,
-		['shop'] = 'luxury',
 	},
 	['osiris'] = {
 		['name'] = 'Osiris',
@@ -3593,7 +3196,6 @@ QBShared.Vehicles = {
 		['price'] = 220000,
 		['category'] = 'super',
 		['hash'] = `osiris`,
-		['shop'] = 'luxury',
 	},
 	['penetrator'] = {
 		['name'] = 'Penetrator',
@@ -3602,7 +3204,6 @@ QBShared.Vehicles = {
 		['price'] = 130000,
 		['category'] = 'super',
 		['hash'] = `penetrator`,
-		['shop'] = 'luxury',
 	},
 	['pfister811'] = {
 		['name'] = '811',
@@ -3611,7 +3212,6 @@ QBShared.Vehicles = {
 		['price'] = 220000,
 		['category'] = 'super',
 		['hash'] = `pfister811`,
-		['shop'] = 'luxury',
 	},
 	['prototipo'] = {
 		['name'] = 'X80 Proto',
@@ -3620,7 +3220,6 @@ QBShared.Vehicles = {
 		['price'] = 235000,
 		['category'] = 'super',
 		['hash'] = `prototipo`,
-		['shop'] = 'luxury',
 	},
 	['reaper'] = {
 		['name'] = 'Reaper',
@@ -3629,7 +3228,6 @@ QBShared.Vehicles = {
 		['price'] = 100000,
 		['category'] = 'super',
 		['hash'] = `reaper`,
-		['shop'] = 'luxury',
 	},
 	['s80'] = {							--DLC
 		['name'] = 'S80RR',
@@ -3638,7 +3236,6 @@ QBShared.Vehicles = {
 		['price'] = 205000,
 		['category'] = 'super',
 		['hash'] = `s80`,
-		['shop'] = 'luxury',
 	},
 	['sc1'] = {
 		['name'] = 'SC1',
@@ -3647,7 +3244,6 @@ QBShared.Vehicles = {
 		['price'] = 90000,
 		['category'] = 'super',
 		['hash'] = `sc1`,
-		['shop'] = 'luxury',
 	},
 	['sheava'] = {							--DLC
 		['name'] = 'ETR1',
@@ -3656,7 +3252,6 @@ QBShared.Vehicles = {
 		['price'] = 220000,
 		['category'] = 'super',
 		['hash'] = `sheava`,
-		['shop'] = 'luxury',
 	},
 	['sultanrs'] = {
 		['name'] = 'Sultan RS',
@@ -3665,7 +3260,6 @@ QBShared.Vehicles = {
 		['price'] = 76500,
 		['category'] = 'sports',
 		['hash'] = `sultanrs`,
-		['shop'] = 'luxury',
 	},
 	['t20'] = {
 		['name'] = 'T20',
@@ -3674,7 +3268,6 @@ QBShared.Vehicles = {
 		['price'] = 1650000,
 		['category'] = 'super',
 		['hash'] = `t20`,
-		['shop'] = 'luxury',
 	},
 	['taipan'] = {
 		['name'] = 'Taipan',
@@ -3683,7 +3276,6 @@ QBShared.Vehicles = {
 		['price'] = 1850000,
 		['category'] = 'super',
 		['hash'] = `taipan`,
-		['shop'] = 'luxury',
 	},
 	['tempesta'] = {
 		['name'] = 'Tempesta',
@@ -3692,7 +3284,6 @@ QBShared.Vehicles = {
 		['price'] = 120000,
 		['category'] = 'super',
 		['hash'] = `tempesta`,
-		['shop'] = 'luxury',
 	},
 	['tezeract'] = {
 		['name'] = 'Tezeract',
@@ -3701,7 +3292,6 @@ QBShared.Vehicles = {
 		['price'] = 220000,
 		['category'] = 'super',
 		['hash'] = `tezeract`,
-		['shop'] = 'luxury',
 	},
 	['thrax'] = {							--DLC
 		['name'] = 'Thrax',
@@ -3710,7 +3300,6 @@ QBShared.Vehicles = {
 		['price'] = 180000,
 		['category'] = 'super',
 		['hash'] = `thrax`,
-		['shop'] = 'luxury',
 	},
 	['tigon'] = {
 		['name'] = 'Tigon',
@@ -3719,7 +3308,6 @@ QBShared.Vehicles = {
 		['price'] = 240000,
 		['category'] = 'super',
 		['hash'] = `tigon`,
-		['shop'] = 'luxury',
 	},
 	['turismor'] = {
 		['name'] = 'Turismo R',
@@ -3728,7 +3316,6 @@ QBShared.Vehicles = {
 		['price'] = 140000,
 		['category'] = 'super',
 		['hash'] = `turismor`,
-		['shop'] = 'luxury',
 	},
 	['tyrant'] = {
 		['name'] = 'Tyrant',
@@ -3737,7 +3324,6 @@ QBShared.Vehicles = {
 		['price'] = 2100000,
 		['category'] = 'super',
 		['hash'] = `tyrant`,
-		['shop'] = 'luxury',
 	},
 	['tyrus'] = {
 		['name'] = 'Tyrus',
@@ -3746,7 +3332,6 @@ QBShared.Vehicles = {
 		['price'] = 230000,
 		['category'] = 'super',
 		['hash'] = `tyrus`,
-		['shop'] = 'luxury',
 	},
 	['vacca'] = {
 		['name'] = 'Vacca',
@@ -3755,7 +3340,6 @@ QBShared.Vehicles = {
 		['price'] = 105000,
 		['category'] = 'super',
 		['hash'] = `vacca`,
-		['shop'] = 'luxury',
 	},
 	['vagner'] = {
 		['name'] = 'Vagner',
@@ -3764,7 +3348,6 @@ QBShared.Vehicles = {
 		['price'] = 1660000,
 		['category'] = 'super',
 		['hash'] = `vagner`,
-		['shop'] = 'luxury',
 	},
 	['visione'] = {
 		['name'] = 'Visione',
@@ -3773,7 +3356,6 @@ QBShared.Vehicles = {
 		['price'] = 750000,
 		['category'] = 'sports',
 		['hash'] = `visione`,
-		['shop'] = 'luxury',
 	},
 	['voltic'] = {
 		['name'] = 'Voltic',
@@ -3782,7 +3364,6 @@ QBShared.Vehicles = {
 		['price'] = 120000,
 		['category'] = 'super',
 		['hash'] = `voltic`,
-		['shop'] = 'luxury',
 	},
 	['voltic2'] = {
 		['name'] = 'Rocket Voltic',
@@ -3791,7 +3372,6 @@ QBShared.Vehicles = {
 		['price'] = 9830400,
 		['category'] = 'super',
 		['hash'] = `voltic2`,
-		['shop'] = 'luxury',
 	},
 	['xa21'] = {
 		['name'] = 'XA-21',
@@ -3800,7 +3380,6 @@ QBShared.Vehicles = {
 		['price'] = 180000,
 		['category'] = 'super',
 		['hash'] = `xa21`,
-		['shop'] = 'luxury',
 	},
 	['zentorno'] = {
 		['name'] = 'Zentorno',
@@ -3809,7 +3388,6 @@ QBShared.Vehicles = {
 		['price'] = 340000,
 		['category'] = 'super',
 		['hash'] = `zentorno`,
-		['shop'] = 'luxury',
 	},
 	['zorrusso'] = {							--DLC
 		['name'] = 'Zorrusso',
@@ -3818,7 +3396,6 @@ QBShared.Vehicles = {
 		['price'] = 277000,
 		['category'] = 'super',
 		['hash'] = `zorrusso`,
-		['shop'] = 'luxury',
 	},
 	-- Vans
 	['bison'] = {
@@ -3828,7 +3405,6 @@ QBShared.Vehicles = {
 		['price'] = 18000,
 		['category'] = 'vans',
 		['hash'] = `bison`,
-		['shop'] = 'pdm',
 	},
 	['bobcatxl'] = {
 		['name'] = 'Bobcat XL Open',
@@ -3837,7 +3413,6 @@ QBShared.Vehicles = {
 		['price'] = 13500,
 		['category'] = 'vans',
 		['hash'] = `bobcatxl`,
-		['shop'] = 'pdm',
 	},
 	['burrito3'] = {
 		['name'] = 'Burrito',
@@ -3846,7 +3421,6 @@ QBShared.Vehicles = {
 		['price'] = 4000,
 		['category'] = 'vans',
 		['hash'] = `burrito3`,
-		['shop'] = 'pdm',
 	},
 	['gburrito2'] = {
 		['name'] = 'Burrito Custom',
@@ -3855,7 +3429,6 @@ QBShared.Vehicles = {
 		['price'] = 11500,
 		['category'] = 'vans',
 		['hash'] = `gburrito2`,
-		['shop'] = 'pdm',
 	},
 	['rumpo'] = {
 		['name'] = 'Rumpo',
@@ -3864,7 +3437,6 @@ QBShared.Vehicles = {
 		['price'] = 9000,
 		['category'] = 'vans',
 		['hash'] = `rumpo`,
-		['shop'] = 'pdm',
 	},
 	['journey'] = {
 		['name'] = 'Journey',
@@ -3873,7 +3445,6 @@ QBShared.Vehicles = {
 		['price'] = 6500,
 		['category'] = 'vans',
 		['hash'] = `journey`,
-		['shop'] = 'pdm',
 	},
 	['minivan'] = {
 		['name'] = 'Minivan',
@@ -3882,7 +3453,6 @@ QBShared.Vehicles = {
 		['price'] = 7000,
 		['category'] = 'vans',
 		['hash'] = `minivan`,
-		['shop'] = 'pdm',
 	},
 	['minivan2'] = {
 		['name'] = 'Minivan Custom',
@@ -3891,7 +3461,6 @@ QBShared.Vehicles = {
 		['price'] = 10000,
 		['category'] = 'vans',
 		['hash'] = `minivan2`,
-		['shop'] = 'pdm',
 	},
 	['paradise'] = {
 		['name'] = 'Paradise',
@@ -3900,7 +3469,6 @@ QBShared.Vehicles = {
 		['price'] = 9000,
 		['category'] = 'vans',
 		['hash'] = `paradise`,
-		['shop'] = 'pdm',
 	},
 	['rumpo3'] = {
 		['name'] = 'Rumpo Custom',
@@ -3909,7 +3477,6 @@ QBShared.Vehicles = {
 		['price'] = 19500,
 		['category'] = 'vans',
 		['hash'] = `rumpo3`,
-		['shop'] = 'pdm',
 	},
 	['speedo'] = {
 		['name'] = 'Speedo',
@@ -3918,7 +3485,6 @@ QBShared.Vehicles = {
 		['price'] = 10000,
 		['category'] = 'vans',
 		['hash'] = `speedo`,
-		['shop'] = 'pdm',
 	},
 	['speedo4'] = {
 		['name'] = 'Speedo Custom',
@@ -3927,7 +3493,6 @@ QBShared.Vehicles = {
 		['price'] = 15000,
 		['category'] = 'vans',
 		['hash'] = `speedo4`,
-		['shop'] = 'pdm',
 	},
 	['surfer'] = {
 		['name'] = 'Surfer',
@@ -3936,7 +3501,6 @@ QBShared.Vehicles = {
 		['price'] = 9000,
 		['category'] = 'vans',
 		['hash'] = `surfer`,
-		['shop'] = 'pdm',
 	},
 	['youga3'] = {
 		['name'] = 'Youga Classic 4x4',
@@ -3945,7 +3509,6 @@ QBShared.Vehicles = {
 		['price'] = 15000,
 		['category'] = 'vans',
 		['hash'] = `youga3`,
-		['shop'] = 'pdm',
 	},
 	['youga'] = {
 		['name'] = 'Youga',
@@ -3954,7 +3517,6 @@ QBShared.Vehicles = {
 		['price'] = 8000,
 		['category'] = 'vans',
 		['hash'] = `youga`,
-		['shop'] = 'pdm',
 	},
 	['youga2'] = {
 		['name'] = 'Youga Classic',
@@ -3963,7 +3525,6 @@ QBShared.Vehicles = {
 		['price'] = 14500,
 		['category'] = 'vans',
 		['hash'] = `youga2`,
-		['shop'] = 'pdm',
 	},
 	['youga4'] = { 	 	--DLC +set sv_enforceGameBuild 2545
 		['name'] = 'Youga',
@@ -3972,7 +3533,6 @@ QBShared.Vehicles = {
 		['price'] = 85000,
 		['category'] = 'vans',
 		['hash'] = `youga4`,
-		['shop'] = 'pdm',
 	},
 	['mule5'] = { 	 	--DLC +set sv_enforceGameBuild 2545
 		['name'] = 'Mule',
@@ -3981,7 +3541,6 @@ QBShared.Vehicles = {
 		['price'] = 221000,
 		['category'] = 'vans',
 		['hash'] = `mule5`,
-		['shop'] = 'pdm',
 	},
 	-- Utility
 	['sadler'] = {
@@ -3991,7 +3550,6 @@ QBShared.Vehicles = {
 		['price'] = 20000,
 		['category'] = 'offroad',
 		['hash'] = `sadler`,
-		['shop'] = 'pdm',
 	},
 	['guardian'] = {
 		['name'] = 'Guardian',
@@ -4000,7 +3558,6 @@ QBShared.Vehicles = {
 		['category'] = 'offroad',
 		['model'] = 'guardian',
 		['hash'] = `guardian`,
-		['shop'] = 'pdm',
 	},
 	['slamtruck'] = {
 		['name'] = 'Slam Truck',
@@ -4009,7 +3566,6 @@ QBShared.Vehicles = {
 		['price'] = 100000,
 		['category'] = 'muscle',
 		['hash'] = `slamtruck`,
-		['shop'] = 'pdm',
 	},
 	['warrener2'] = {							--DLC +set sv_enforceGameBuild 2372
 		['name'] = 'Warrener HKR',
@@ -4018,7 +3574,6 @@ QBShared.Vehicles = {
 		['price'] = 30000,
 		['category'] = 'sedans',
 		['hash'] = `warrener2`,
-		['shop'] = 'pdm',
 	},
 		-- Boats
 	['squalo'] = {
@@ -4028,7 +3583,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'boats',
 		['hash'] = `squalo`,
-		['shop'] = 'boats',
 	},
 	['marquis'] = {
 		['name'] = 'Marquis',
@@ -4037,7 +3591,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'boats',
 		['hash'] = `marquis`,
-		['shop'] = 'boats',
 	},
 	['seashark'] = {
 		['name'] = 'Seashark',
@@ -4046,7 +3599,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'boats',
 		['hash'] = `seashark`,
-		['shop'] = 'boats',
 	},
 	['seashark2'] = {
 		['name'] = 'Seashark',
@@ -4055,7 +3607,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'boats',
 		['hash'] = `seashark2`,
-		['shop'] = 'boats',
 	},
 	['seashark3'] = {
 		['name'] = 'Seashark',
@@ -4064,7 +3615,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'boats',
 		['hash'] = `seashark3`,
-		['shop'] = 'boats',
 	},
 	['jetmax'] = {
 		['name'] = 'Shitzu',
@@ -4073,7 +3623,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'boats',
 		['hash'] = `jetmax`,
-		['shop'] = 'boats',
 	},
 	['tropic'] = {
 		['name'] = 'Shitzu',
@@ -4082,7 +3631,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'boats',
 		['hash'] = `tropic`,
-		['shop'] = 'boats',
 	},
 	['tropic2'] = {
 		['name'] = 'Shitzu',
@@ -4091,7 +3639,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'boats',
 		['hash'] = `tropic2`,
-		['shop'] = 'boats',
 	},
 	['dinghy'] = {
 		['name'] = 'Nagasaki',
@@ -4100,7 +3647,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'boats',
 		['hash'] = `dinghy`,
-		['shop'] = 'boats',
 	},
 	['dinghy2'] = {
 		['name'] = 'Nagasaki',
@@ -4109,7 +3655,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'boats',
 		['hash'] = `dinghy2`,
-		['shop'] = 'boats',
 	},
 	['dinghy3'] = {
 		['name'] = 'Nagasaki',
@@ -4118,7 +3663,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'boats',
 		['hash'] = `dinghy3`,
-		['shop'] = 'boats',
 	},
 	['dinghy4'] = {
 		['name'] = 'Nagasaki',
@@ -4127,7 +3671,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'boats',
 		['hash'] = `dinghy4`,
-		['shop'] = 'boats',
 	},
 	['suntrap'] = {
 		['name'] = 'Shitzu',
@@ -4136,7 +3679,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'boats',
 		['hash'] = `suntrap`,
-		['shop'] = 'boats',
 	},
 	['speeder'] = {
 		['name'] = 'Speeder',
@@ -4145,7 +3687,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'boats',
 		['hash'] = `speeder`,
-		['shop'] = 'boats',
 	},
 	['speeder2'] = {
 		['name'] = 'Speeder',
@@ -4154,7 +3695,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'boats',
 		['hash'] = `speeder2`,
-		['shop'] = 'boats',
 	},
 	['longfin'] = {
 		['name'] = 'Longfin',
@@ -4163,7 +3703,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'boats',
 		['hash'] = `longfin`,
-		['shop'] = 'boats',
 	},
 	['toro'] = {
 		['name'] = 'Toro',
@@ -4172,7 +3711,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'boats',
 		['hash'] = `toro`,
-		['shop'] = 'boats',
 	},
 	['toro2'] = {
 		['name'] = 'Toro',
@@ -4181,7 +3719,6 @@ QBShared.Vehicles = {
 		['price'] = 40000,
 		['category'] = 'boats',
 		['hash'] = `toro2`,
-		['shop'] = 'boats',
 	},
 	-- helicopters
 	['buzzard2'] = {
@@ -4191,7 +3728,6 @@ QBShared.Vehicles = {
 		['price'] = 52000,
 		['category'] = 'helicopters',
 		['hash'] = `buzzard2`,
-		['shop'] = 'air',
 	},
 	['frogger'] = {
 		['name'] = 'Frogger',
@@ -4200,7 +3736,6 @@ QBShared.Vehicles = {
 		['price'] = 52000,
 		['category'] = 'helicopters',
 		['hash'] = `frogger`,
-		['shop'] = 'air',
 	},
 	['frogger2'] = {
 		['name'] = 'Frogger',
@@ -4209,7 +3744,6 @@ QBShared.Vehicles = {
 		['price'] = 52000,
 		['category'] = 'helicopters',
 		['hash'] = `frogger2`,
-		['shop'] = 'air',
 	},
 	['maverick'] = {
 		['name'] = 'Maverick',
@@ -4218,7 +3752,6 @@ QBShared.Vehicles = {
 		['price'] = 52000,
 		['category'] = 'helicopters',
 		['hash'] = `maverick`,
-		['shop'] = 'air',
 	},
 	['swift'] = {
 		['name'] = 'Swift',
@@ -4227,7 +3760,6 @@ QBShared.Vehicles = {
 		['price'] = 52000,
 		['category'] = 'helicopters',
 		['hash'] = `swift`,
-		['shop'] = 'air',
 	},
 	['swift2'] = {
 		['name'] = 'Swift',
@@ -4236,7 +3768,6 @@ QBShared.Vehicles = {
 		['price'] = 52000,
 		['category'] = 'helicopters',
 		['hash'] = `swift2`,
-		['shop'] = 'air',
 	},
 	['seasparrow'] = {
 		['name'] = 'Sea Sparrow',
@@ -4245,7 +3776,6 @@ QBShared.Vehicles = {
 		['price'] = 52000,
 		['category'] = 'helicopters',
 		['hash'] = `seasparrow`,
-		['shop'] = 'air',
 	},
 	['seasparrow2'] = {
 		['name'] = 'Sparrow',
@@ -4254,7 +3784,6 @@ QBShared.Vehicles = {
 		['price'] = 52000,
 		['category'] = 'helicopters',
 		['hash'] = `seasparrow2`,
-		['shop'] = 'air',
 	},
 	['seasparrow3'] = {
 		['name'] = 'Sparrow',
@@ -4263,7 +3792,6 @@ QBShared.Vehicles = {
 		['price'] = 52000,
 		['category'] = 'helicopters',
 		['hash'] = `seasparrow3`,
-		['shop'] = 'air',
 	},
 	['supervolito'] = {
 		['name'] = 'SuperVolito',
@@ -4272,7 +3800,6 @@ QBShared.Vehicles = {
 		['price'] = 52000,
 		['category'] = 'helicopters',
 		['hash'] = `supervolito`,
-		['shop'] = 'air',
 	},
 	['supervolito2'] = {
 		['name'] = 'SuperVolito Carbon',
@@ -4281,7 +3808,6 @@ QBShared.Vehicles = {
 		['price'] = 52000,
 		['category'] = 'helicopters',
 		['hash'] = `supervolito2`,
-		['shop'] = 'air',
 	},
 	['volatus'] = {
 		['name'] = 'Volatus',
@@ -4290,7 +3816,6 @@ QBShared.Vehicles = {
 		['price'] = 52000,
 		['category'] = 'helicopters',
 		['hash'] = `volatus`,
-		['shop'] = 'air',
 	},
 	['havok'] = {
 		['name'] = 'Havok',
@@ -4299,7 +3824,6 @@ QBShared.Vehicles = {
 		['price'] = 52000,
 		['category'] = 'helicopters',
 		['hash'] = `havok`,
-		['shop'] = 'air',
 	},
 	-- Planes
 	['duster'] = {
@@ -4309,7 +3833,6 @@ QBShared.Vehicles = {
 		['price'] = 45000,
 		['category'] = 'planes',
 		['hash'] = `duster`,
-		['shop'] = 'air',
 	},
 	['luxor'] = {
 		['name'] = 'Luxor',
@@ -4318,7 +3841,6 @@ QBShared.Vehicles = {
 		['price'] = 45000,
 		['category'] = 'planes',
 		['hash'] = `luxor`,
-		['shop'] = 'air',
 	},
 	['luxor2'] = {
 		['name'] = 'Luxor Deluxe',
@@ -4327,7 +3849,6 @@ QBShared.Vehicles = {
 		['price'] = 45000,
 		['category'] = 'planes',
 		['hash'] = `luxor2`,
-		['shop'] = 'air',
 	},
 	['stunt'] = {
 		['name'] = 'Mallard',
@@ -4336,7 +3857,6 @@ QBShared.Vehicles = {
 		['price'] = 45000,
 		['category'] = 'planes',
 		['hash'] = `stunt`,
-		['shop'] = 'air',
 	},
 	['mammatus'] = {
 		['name'] = 'Mammatus',
@@ -4345,7 +3865,6 @@ QBShared.Vehicles = {
 		['price'] = 45000,
 		['category'] = 'planes',
 		['hash'] = `mammatus`,
-		['shop'] = 'air',
 	},
 	['velum'] = {
 		['name'] = 'Velum',
@@ -4354,7 +3873,6 @@ QBShared.Vehicles = {
 		['price'] = 45000,
 		['category'] = 'planes',
 		['hash'] = `velum`,
-		['shop'] = 'air',
 	},
 	['velum2'] = {
 		['name'] = 'Velum',
@@ -4363,7 +3881,6 @@ QBShared.Vehicles = {
 		['price'] = 45000,
 		['category'] = 'planes',
 		['hash'] = `velum2`,
-		['shop'] = 'air',
 	},
 	['shamal'] = {
 		['name'] = 'Shamal',
@@ -4372,7 +3889,6 @@ QBShared.Vehicles = {
 		['price'] = 45000,
 		['category'] = 'planes',
 		['hash'] = `shamal`,
-		['shop'] = 'air',
 	},
 	['vestra'] = {
 		['name'] = 'Vestra',
@@ -4381,7 +3897,6 @@ QBShared.Vehicles = {
 		['price'] = 45000,
 		['category'] = 'planes',
 		['hash'] = `vestra`,
-		['shop'] = 'air',
 	},
 	['dodo'] = {
 		['name'] = 'Dodo',
@@ -4390,7 +3905,6 @@ QBShared.Vehicles = {
 		['price'] = 45000,
 		['category'] = 'planes',
 		['hash'] = `dodo`,
-		['shop'] = 'air',
 	},
 	['howard'] = {
 		['name'] = 'Howard NX-25',
@@ -4399,7 +3913,6 @@ QBShared.Vehicles = {
 		['price'] = 45000,
 		['category'] = 'planes',
 		['hash'] = `howard`,
-		['shop'] = 'air',
 	},
 	['alphaz1'] = {
 		['name'] = 'Alpha-Z1',
@@ -4408,7 +3921,6 @@ QBShared.Vehicles = {
 		['price'] = 45000,
 		['category'] = 'planes',
 		['hash'] = `alphaz1`,
-		['shop'] = 'air',
 	},
 	['nimbus'] = {
 		['name'] = 'Nimbus',
@@ -4417,7 +3929,6 @@ QBShared.Vehicles = {
 		['price'] = 45000,
 		['category'] = 'planes',
 		['hash'] = `nimbus`,
-		['shop'] = 'air',
 	},
 	['brioso3'] = {          --DLC +set sv_enforceGameBuild 2699 (and below)
         ['name'] = 'Brioso 300 Widebody',


### PR DESCRIPTION
Removed the shop key as it is unneeded with the latest vehicleshop change.

I removed the shop key to coincide with the qb-vehicleshop pull request 250. https://github.com/qbcore-framework/qb-vehicleshop/pull/250 

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

It removes the unneeded logic check and the unnecessary key and value pairs. As such reducing the amount of memory used based on the number of cars loaded into vehicles.lua and the shared.vehicles table.

I have been running this on a live server for 2 months along with the matched changes in the previous mentiond pull request. No errors have been detected in that time period. 

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [ x] My code fits the style guidelines.
- [ x] My PR fits the contribution guidelines.
