### PR TITLE
Have SetJobDuty also trigger job updates

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -251,6 +251,8 @@ function QBCore.Player.CreatePlayer(PlayerData, Offline)
 
     function self.Functions.SetJobDuty(onDuty)
         self.PlayerData.job.onduty = not not onDuty -- Make sure the value is a boolean if nil is sent
+        TriggerEvent('QBCore:Server:OnJobUpdate', self.PlayerData.source, self.PlayerData.job)
+        TriggerClientEvent('QBCore:Client:OnJobUpdate', self.PlayerData.source, self.PlayerData.job)
         self.Functions.UpdatePlayerData()
     end
 


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Has SetJobDuty update the job. This fixes issues with alternative methods to going on duty other than those in the specific scripts that set their own onDuty variables. Should probably also deprecate all those onDuty variables in various scripts like qb-policejob.

qb-policejob clean up PR that relies on this one: https://github.com/qbcore-framework/qb-policejob/pull/394

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
