### PR TITLE
Update functions.lua

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -209,7 +209,7 @@ function PaycheckInterval()
                 if Player.PlayerData.job and payment > 0 and (QBShared.Jobs[Player.PlayerData.job.name].offDutyPay or Player.PlayerData.job.onduty) then
                     if QBCore.Config.Money.PayCheckSociety then
                         local account = exports['qb-management']:GetAccount(Player.PlayerData.job.name)
-                        if account ~= 0 then -- Checks if player is employed by a society
+                        if account ~= false then -- Checks if player is employed by a society
                             if account < payment then -- Checks if company has enough money to pay society
                                 TriggerClientEvent('QBCore:Notify', Player.PlayerData.source, Lang:t('error.company_too_poor'), 'error')
                             else


### PR DESCRIPTION
## Description

Instead of `0`, I believe it way better to use `false` where it could actually indicate of non-existence of the account as it may have `0` balance in the account and it is still going to give the player paycheck.

This is connected with my pull-request in ` qb-management`: https://github.com/qbcore-framework/qb-management/pull/73
