### PR TITLE
Remove armed vehicle from shared

### DIFF
--- a/shared/vehicles.lua
+++ b/shared/vehicles.lua
@@ -1529,15 +1529,6 @@ QBShared.Vehicles = {
 		['hash'] = `brawler`,
 		['shop'] = 'pdm',
 	},
-	['caracara'] = {
-		['name'] = 'Caracara',
-		['brand'] = 'Vapid',
-		['model'] = 'caracara',
-		['price'] = 60000,
-		['category'] = 'offroad',
-		['hash'] = `caracara`,
-		['shop'] = 'pdm',
-	},
 	['caracara2'] = {							--DLC
 		['name'] = 'Caracara 4x4',
 		['brand'] = 'Vapid',


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

The caracara (armed PDM vehicle with technical) shouldn't be purchasable by players as a default car

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x ] I have personally loaded this code into an updated QB-Core project and checked all of its functionality.
- [x ] My code fits the style guidelines.
- [x ] My PR fits the contribution guidelines.
