### PR TITLE
Add qb-cityhall AddJob export

### DIFF
--- a/server/exports.lua
+++ b/server/exports.lua
@@ -42,6 +42,7 @@ local function AddJob(jobName, job)
 
     QBCore.Shared.Jobs[jobName] = job
 
+    exports["qb-cityhall"]:AddCityJob(job, jobName)
     TriggerClientEvent('QBCore:Client:OnSharedUpdate', -1, 'Jobs', jobName, job)
     TriggerEvent('QBCore:Server:UpdateObject')
     return true, "success"


### PR DESCRIPTION
## Description
This add the AddJob export from qb-cityhall added in https://github.com/qbcore-framework/qb-cityhall/pull/81 to automatically add the job to the qb-cityhall UI menu.

Requires https://github.com/qbcore-framework/qb-cityhall/pull/81 to be merged first.
## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
