### PR TITLE
Replace breaks with Returns

### DIFF
--- a/server/exports.lua
+++ b/server/exports.lua
@@ -61,14 +61,14 @@ local function AddJobs(jobs)
             message = 'invalid_job_name'
             shouldContinue = false
             errorItem = jobs[key]
-            break
+            return
         end
 
         if QBCore.Shared.Jobs[key] then
             message = 'job_exists'
             shouldContinue = false
             errorItem = jobs[key]
-            break
+            return
         end
 
         QBCore.Shared.Jobs[key] = value
@@ -171,14 +171,14 @@ local function AddItems(items)
             message = "invalid_item_name"
             shouldContinue = false
             errorItem = items[key]
-            break
+            return
         end
 
         if QBCore.Shared.Items[key] then
             message = "item_exists"
             shouldContinue = false
             errorItem = items[key]
-            break
+            return
         end
 
         QBCore.Shared.Items[key] = value
@@ -244,14 +244,14 @@ local function AddGangs(gangs)
             message = "invalid_gang_name"
             shouldContinue = false
             errorItem = gangs[key]
-            break
+            return
         end
 
         if QBCore.Shared.Gangs[key] then
             message = "gang_exists"
             shouldContinue = false
             errorItem = gangs[key]
-            break
+            return
         end
 
         QBCore.Shared.Gangs[key] = value


### PR DESCRIPTION
currently when adding multiple jobs or items or gangs if there is a duplicate it breaks the loop instead of returning and going to the next item.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x ] My code fits the style guidelines.
- [ x] My PR fits the contribution guidelines.
