### PR TITLE
🐛  Adding Logs For /me as it doesnt come default with the event for it in commands.lua 🐛 

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -290,7 +290,7 @@ QBCore.Commands.Add('me', Lang:t("command.me.help"), {{name = Lang:t("command.me
         local tCoords = GetEntityCoords(target)
         if target == ped or #(pCoords - tCoords) < 20 then
             TriggerClientEvent('QBCore:Command:ShowMe3D', Player, source, msg)
-            TriggerEvent('qb-log:server:CreateLog', 'me', 'Me Command Log', 'white', '**ID: ' .. source .. ') Message:** ' .. msg, false)
+            TriggerEvent('qb-log:server:CreateLog', 'me', 'Me Command Log', 'white', '**User ID: ' .. source .. 'User Message:** ' .. msg, false)
         end
     end
 end, 'user')

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -290,6 +290,7 @@ QBCore.Commands.Add('me', Lang:t("command.me.help"), {{name = Lang:t("command.me
         local tCoords = GetEntityCoords(target)
         if target == ped or #(pCoords - tCoords) < 20 then
             TriggerClientEvent('QBCore:Command:ShowMe3D', Player, source, msg)
+                TriggerEvent('qb-log:server:CreateLog', 'me', Player, 'lightgreen', msg)
         end
     end
 end, 'user')

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -290,7 +290,7 @@ QBCore.Commands.Add('me', Lang:t("command.me.help"), {{name = Lang:t("command.me
         local tCoords = GetEntityCoords(target)
         if target == ped or #(pCoords - tCoords) < 20 then
             TriggerClientEvent('QBCore:Command:ShowMe3D', Player, source, msg)
-            TriggerEvent('qb-log:server:CreateLog', 'me', 'Me Command Log', 'white', '**User ID: ' .. source .. 'User Message:** ' .. msg, false)
+            TriggerEvent('qb-log:server:CreateLog', 'me', 'Me Command Log', 'white', '**User ID: ' .. source .. ' - User Message:** ' .. msg, false)
         end
     end
 end, 'user')

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -288,9 +288,11 @@ QBCore.Commands.Add('me', Lang:t("command.me.help"), {{name = Lang:t("command.me
         local Player = Players[i]
         local target = GetPlayerPed(Player)
         local tCoords = GetEntityCoords(target)
+        local Player = QBCore.Functions.GetPlayer(source)
+        local citizenID = Player.PlayerData.citizenid
         if target == ped or #(pCoords - tCoords) < 20 then
             TriggerClientEvent('QBCore:Command:ShowMe3D', Player, source, msg)
-            TriggerEvent('qb-log:server:CreateLog', 'me', 'Me Command Log', 'white', '**User ID: ' .. source .. ' - User Message:** ' .. msg, false)
+            TriggerEvent('qb-log:server:CreateLog', 'me', 'Me Command Used By **User: **' .. GetPlayerName(source) , 'white', '**Player ID: ' .. Player .. '\n\n User Message:** ' .. msg, false)
         end
     end
 end, 'user')

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -290,7 +290,7 @@ QBCore.Commands.Add('me', Lang:t("command.me.help"), {{name = Lang:t("command.me
         local tCoords = GetEntityCoords(target)
         if target == ped or #(pCoords - tCoords) < 20 then
             TriggerClientEvent('QBCore:Command:ShowMe3D', Player, source, msg)
-                TriggerEvent('qb-log:server:CreateLog', 'me', Player, 'lightgreen', msg)
+            TriggerEvent('qb-log:server:CreateLog', 'me', 'Me Command Log', 'white', '**ID: ' .. source .. ') Message:** ' .. msg, false)
         end
     end
 end, 'user')


### PR DESCRIPTION
## Adding 

so by default.... the ``qb-smallresources/server/logs.lua`` there is a ``['me'] = '',`` logs.... by default
and in the file ``qb-core/server/commands.lua`` at the bottom there is no logs export and this may annoy some people that wants logs... and they will open a support thread in support and this will happen over and over again and people will have to keep asking for the event to paste it in!

Discord: Preview: https://part-of-the.cutecatgirl.club/BtEj0KtY7abb
Alive: Preview: https://part-of-the.cutecatgirl.club/HXoanshrOmXF
Dead: Preview: https://part-of-the.cutecatgirl.club/EvY9ARlgBQZg

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.