### PR TITLE
refactor: search for tables instead of reading a table

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -28,6 +28,7 @@ QBConfig.Server.PVP = true -- Enable or disable pvp on the server (Ability to sh
 QBConfig.Server.Discord = "" -- Discord invite link
 QBConfig.Server.CheckDuplicateLicense = true -- Check for duplicate rockstar license on join
 QBConfig.Server.Permissions = { 'god', 'admin', 'mod' } -- Add as many groups as you want here after creating them in your server.cfg
+QBConfig.Server.CharacterDeletion = { 'citizenid', 'id', 'user_id' } -- Add as table names as needed
 
 QBConfig.Notify = {}
 


### PR DESCRIPTION
## Description
Instead of reading a hardcoded list, this will request all the tables that contains some names from `QBConfig.Server.CharacterDeletion`.

## Checklist
- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
