### PR TITLE
[FIX] Remove vehicle keys depdency from core

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -160,6 +160,12 @@ end)
 
 RegisterNetEvent('QBCore:Client:VehicleInfo', function(info)
     local plate = QBCore.Functions.GetPlate(info.vehicle)
+    local hasKeys = true
+
+    if GetResourceState('qb-vehiclekeys') == 'started' then
+        hasKeys = exports['qb-vehiclekeys']:HasKeys()
+    end
+
     local data = {
         vehicle = info.vehicle,
         seat = info.seat,
@@ -167,8 +173,9 @@ RegisterNetEvent('QBCore:Client:VehicleInfo', function(info)
         plate = plate,
         driver = GetPedInVehicleSeat(info.vehicle, -1),
         inseat = GetPedInVehicleSeat(info.vehicle, info.seat),
-        haskeys = exports['qb-vehiclekeys']:HasKeys(plate)
+        haskeys = hasKeys
     }
+
     TriggerEvent('QBCore:Client:'..info.event..'Vehicle', data)
 end)
 


### PR DESCRIPTION
## Description
Without `qb-vehiclekeys` running, an error is shown in the console when entering vehicles.
This code will check if `qb-vehiclekeys` is running before relying on the exported function `HasKeys` from being present.

The reason I don't want `qb-vehiclekeys` is that I run more of a free roam oriented server.

## Checklist

- [X] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
