### PR TITLE
bugfix: force clear vehicle custom colors before applying colors

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -605,6 +605,7 @@ function QBCore.Functions.SetVehicleProperties(vehicle, props)
         end
         if props.color1 then
             if type(props.color1) == "number" then
+                ClearVehicleCustomPrimaryColour(vehicle)
                 SetVehicleColours(vehicle, props.color1, colorSecondary)
             else
                 SetVehicleCustomPrimaryColour(vehicle, props.color1[1], props.color1[2], props.color1[3])
@@ -612,6 +613,7 @@ function QBCore.Functions.SetVehicleProperties(vehicle, props)
         end
         if props.color2 then
             if type(props.color2) == "number" then
+                ClearVehicleCustomSecondaryColour(vehicle)
                 SetVehicleColours(vehicle, props.color1 or colorPrimary, props.color2)
             else
                 SetVehicleCustomSecondaryColour(vehicle, props.color2[1], props.color2[2], props.color2[3])


### PR DESCRIPTION
## Description

This pull request fixes the issue where standard vehicle colors wouldn't be applied if it had custom color applied before.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [✅] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [✅] My code fits the style guidelines.
- [✅] My PR fits the contribution guidelines.
