### PR TITLE
Fix drawtext error in html

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -7,8 +7,6 @@
     <link href="css/style.css" rel="stylesheet" />
     <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.prod.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/quasar@2.1.0/dist/quasar.umd.prod.js" defer></script>
-    <script type="module" src="js/app.js"></script>
-    <script src="js/drawtext.js"></script>
     <link rel="stylesheet" href="css/drawtext.css">
   </head>
   <body style="font-family: 'Poppins', sans-serif">
@@ -16,5 +14,7 @@
     <div id="drawtext-container">
       <div id="text" class="text"></div>
     </div>
+    <script type="module" src="js/app.js"></script>
+    <script src="js/drawtext.js"></script>
   </body>
 </html>


### PR DESCRIPTION
1. Start QB-Core on a slow or low-spec computer
2. Access the Debug UI page (localhost:13172)
3. Encounter an error in the drawtext.js file
4. The issue stems from the script loading successfully but any resource call function (hideText) and sending an event message before index.html of all resources are fully loaded on NUI it make
```html
 <div className="text" />
```
Doesn't loaded.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
