### PR TITLE
Update functions.lua

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -493,7 +493,7 @@ function QBCore.Functions.GetVehicleProperties(vehicle)
             windowTint = GetVehicleWindowTint(vehicle),
             windowStatus = windowStatus,
             doorStatus = doorStatus,
-            xenonColor = GetVehicleXenonLightsColour(vehicle),
+            xenonColor = GetVehicleXenonLightsColor(vehicle), --https://docs.fivem.net/natives/?_0x3DFF319A831E0CDB
             neonEnabled = {
                 IsVehicleNeonLightEnabled(vehicle, 0),
                 IsVehicleNeonLightEnabled(vehicle, 1),


### PR DESCRIPTION
Misspelled native https://docs.fivem.net/natives/?_0x3DFF319A831E0CDB

## Description

GetVehicleProperties has a misspelled native 

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [X ] My code fits the style guidelines.
- [X ] My PR fits the contribution guidelines.
