### PR TITLE
Fix subs not getting replaced in locales

### DIFF
--- a/shared/locale.lua
+++ b/shared/locale.lua
@@ -20,7 +20,7 @@ local function translateKey(phrase, subs)
 
     -- Initial Scan over result looking for substituions
     for k, v in pairs(subs) do
-        local templateToFind = '%%{' .. k .. '}'
+        local templateToFind = '%{' .. k .. '}'
         result = result:gsub(templateToFind, tostring(v)) -- string to allow all types
     end
 


### PR DESCRIPTION
## Description

This pull request fixes subs not getting replaced in locale strings. While working with locale strings I found that subs were not getting replaced, after some testing it appears that there is a double % in the template that should not be there. After removing 1 % the subs were getting replaced again. They would also get replaced with no % at all, that being an escape character it's probably best the escape stays in.

## Checklist

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
