### PR TITLE
No Secondary Color If Primary Is Custom!

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -614,7 +614,11 @@ function QBCore.Functions.SetVehicleProperties(vehicle, props)
             if type(props.color2) == "number" then
                 SetVehicleColours(vehicle, props.color1 or colorPrimary, props.color2)
             else
-                SetVehicleCustomSecondaryColour(vehicle, props.color2[1], props.color2[2], props.color2[3])
+                if props.color1 and type(props.color1) == "number" then
+                    SetVehicleColours(vehicle, props.color1, props.color2)
+                else
+                    SetVehicleColours(vehicle, colorPrimary, props.color2)
+                end
             end
         end
         if props.pearlescentColor then

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -612,13 +612,13 @@ function QBCore.Functions.SetVehicleProperties(vehicle, props)
         end
         if props.color2 then
             if type(props.color2) == "number" then
-                SetVehicleColours(vehicle, props.color1 or colorPrimary, props.color2)
-            else
                 if props.color1 and type(props.color1) == "number" then
                     SetVehicleColours(vehicle, props.color1, props.color2)
                 else
                     SetVehicleColours(vehicle, colorPrimary, props.color2)
                 end
+            else
+                SetVehicleCustomSecondaryColour(vehicle, props.color2[1], props.color2[2], props.color2[3])
             end
         end
         if props.pearlescentColor then


### PR DESCRIPTION
# note
so i where working on som paint stuff and noticed my secondary color disappeared from time to time
i tracked the problem down and fixed it

# bug
you would not be able to have any normal secondary color if the primary color where custom since you would pass a tabel into the SetVehicleColours native

SetVehicleColours(vehicle, props.color1 or colorPrimary, props.color2)

# checks
- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
