### PR TITLE
Fix invalid increment syntax in `GetDutyCount()` and `GetPlayersOnDuty()`

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -115,7 +115,7 @@ function QBCore.Functions.GetPlayersOnDuty(job)
         if Player.PlayerData.job.name == job then
             if Player.PlayerData.job.onduty then
                 players[#players + 1] = src
-                count += 1
+                count = count + 1
             end
         end
     end
@@ -130,7 +130,7 @@ function QBCore.Functions.GetDutyCount(job)
     for _, Player in pairs(QBCore.Players) do
         if Player.PlayerData.job.name == job then
             if Player.PlayerData.job.onduty then
-                count += 1
+                count = count + 1
             end
         end
     end


### PR DESCRIPTION
## Description

Fix invalid syntax when incrementing `count` inside `GetPlayersOnDuty()` and `GetDutyCount()`

Had a few scripts throwing errors when calling this function, switching to `x = x + 1` syntax fixed all the console errors I was receiving

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
