### PR TITLE
Create and save metadata "Health" and "Armor" when disconnecting.

### DIFF
--- a/server/events.lua
+++ b/server/events.lua
@@ -9,9 +9,14 @@ end)
 
 AddEventHandler('playerDropped', function(reason)
     local src = source
+    local ped = GetPlayerPed(src)
+    local armor = GetPedArmour(ped)
+    local health = GetEntityHealth(ped)
     if not QBCore.Players[src] then return end
     local Player = QBCore.Players[src]
     TriggerEvent('qb-log:server:CreateLog', 'joinleave', 'Dropped', 'red', '**' .. GetPlayerName(src) .. '** (' .. Player.PlayerData.license .. ') left..' ..'\n **Reason:** ' .. reason)
+    Player.Functions.SetMetaData('health', health)
+    Player.Functions.SetMetaData('armor', armor)
     Player.Functions.Save()
     QBCore.Player_Buckets[Player.PlayerData.license] = nil
     QBCore.Players[src] = nil

--- a/server/player.lua
+++ b/server/player.lua
@@ -108,7 +108,7 @@ function QBCore.Player.CheckPlayerData(source, PlayerData)
     PlayerData.charinfo.account = PlayerData.charinfo.account or QBCore.Functions.CreateAccountNumber()
     -- Metadata
     PlayerData.metadata = PlayerData.metadata or {}
-    PlayerData.metadata['health'] = PlayerData.metadata['health'] or 0
+    PlayerData.metadata['health'] = PlayerData.metadata['health'] or 200
     PlayerData.metadata['armor'] = PlayerData.metadata['armor'] or 0
     PlayerData.metadata['hunger'] = PlayerData.metadata['hunger'] or 100
     PlayerData.metadata['thirst'] = PlayerData.metadata['thirst'] or 100

--- a/server/player.lua
+++ b/server/player.lua
@@ -108,12 +108,13 @@ function QBCore.Player.CheckPlayerData(source, PlayerData)
     PlayerData.charinfo.account = PlayerData.charinfo.account or QBCore.Functions.CreateAccountNumber()
     -- Metadata
     PlayerData.metadata = PlayerData.metadata or {}
+    PlayerData.metadata['health'] = PlayerData.metadata['health'] or 0
+    PlayerData.metadata['armor'] = PlayerData.metadata['armor'] or 0
     PlayerData.metadata['hunger'] = PlayerData.metadata['hunger'] or 100
     PlayerData.metadata['thirst'] = PlayerData.metadata['thirst'] or 100
     PlayerData.metadata['stress'] = PlayerData.metadata['stress'] or 0
     PlayerData.metadata['isdead'] = PlayerData.metadata['isdead'] or false
     PlayerData.metadata['inlaststand'] = PlayerData.metadata['inlaststand'] or false
-    PlayerData.metadata['armor'] = PlayerData.metadata['armor'] or 0
     PlayerData.metadata['ishandcuffed'] = PlayerData.metadata['ishandcuffed'] or false
     PlayerData.metadata['tracker'] = PlayerData.metadata['tracker'] or false
     PlayerData.metadata['injail'] = PlayerData.metadata['injail'] or 0


### PR DESCRIPTION
## Description

Create and save the metadata of "health" and "armor" when disconnecting.
This helps to keep the player's health and armor the same after reconnecting.

## Checklist

- [X] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
