### PR TITLE
 Add code from qb-multicharacter into qb-core

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -724,4 +724,26 @@ function QBCore.Player.CreateSerialNumber()
     return SerialNumber
 end
 
+function QBCore.Player.GiveStarterItems()
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    for _, v in pairs(QBCore.Shared.StarterItems) do
+        local info = {}
+        if v.item == "id_card" then
+            info.citizenid = Player.PlayerData.citizenid
+            info.firstname = Player.PlayerData.charinfo.firstname
+            info.lastname = Player.PlayerData.charinfo.lastname
+            info.birthdate = Player.PlayerData.charinfo.birthdate
+            info.gender = Player.PlayerData.charinfo.gender
+            info.nationality = Player.PlayerData.charinfo.nationality
+        elseif v.item == "driver_license" then
+            info.firstname = Player.PlayerData.charinfo.firstname
+            info.lastname = Player.PlayerData.charinfo.lastname
+            info.birthdate = Player.PlayerData.charinfo.birthdate
+            info.type = "Class C Driver License"
+        end
+        Player.Functions.AddItem(v.item, v.amount, false, info)
+    end
+end
+
 PaycheckInterval() -- This starts the paycheck system


### PR DESCRIPTION
## Description

This task is actually the task of the core in general, To give items when you start using the server
This enables another script to be used for qb-multicharacter
Must work independently for qb-multicharacter and qb-spawn
-------------

Other suggestions to help accomplish it
Checking whether the player is in prison or not must be done through core

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
