### PR TITLE
new metadata

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -161,6 +161,7 @@ function QBCore.Player.CheckPlayerData(source, PlayerData)
     PlayerData.job.label = PlayerData.job.label or 'Civilian'
     PlayerData.job.payment = PlayerData.job.payment or 10
     PlayerData.job.type = PlayerData.job.type or 'none'
+    PlayerData.job.department = PlayerData.job.department or 'LSPD'
     if QBCore.Shared.ForceJobDefaultDutyAtLogin or PlayerData.job.onduty == nil then
         PlayerData.job.onduty = QBCore.Shared.Jobs[PlayerData.job.name].defaultDuty
     end


### PR DESCRIPTION
## Description

The item can be used when the server has more than one police station To extract vehicle
Evidence
The option will be faster when using the condition For example, if the vehicle is to be retrieved at the main police station, the vehicle number one is used livery 1, otherwise the vehicle police station is used livery 2, and so on

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
