### PR TITLE
Remote procedure call

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -128,7 +128,6 @@ function QBCore.Functions.TriggerCallback(name, cb, ...)
 end
 
 function QBCore.Functions.uuid()
-	print('1')
     math.randomseed(GetGameTimer())
     local template ='xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
     return string.gsub(template, '[xy]', function (c)

--- a/client/main.lua
+++ b/client/main.lua
@@ -4,6 +4,7 @@ QBCore.Config = QBConfig
 QBCore.Shared = QBShared
 QBCore.ClientCallbacks = {}
 QBCore.ServerCallbacks = {}
+QBCore.ServerRPC = {} --https://en.wikipedia.org/wiki/Remote_procedure_call
 
 exports('GetCoreObject', function()
     return QBCore

--- a/server/events.lua
+++ b/server/events.lua
@@ -106,6 +106,13 @@ RegisterNetEvent('QBCore:Server:TriggerCallback', function(name, ...)
     end, ...)
 end)
 
+RegisterNetEvent('QBCore:Server:TriggerRpc', function(name, id, ...)
+    local src = source
+    QBCore.Functions.TriggerCallback(name, src, function(...)
+        TriggerClientEvent(id, src, ...)
+    end, ...)
+end)
+
 -- Player
 
 RegisterNetEvent('QBCore:UpdatePlayer', function()

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -365,6 +365,16 @@ function QBCore.Functions.TriggerCallback(name, source, cb, ...)
     QBCore.ServerCallbacks[name](source, cb, ...)
 end
 
+function QBCore.Functions.TriggerRpc(name, source, ...)
+    local result
+
+    QBCore.Functions.TriggerCallback(name, source, function(res)
+        result = res
+    end, ...)
+
+    return result
+end
+
 -- Items
 
 ---Create a usable item

--- a/server/main.lua
+++ b/server/main.lua
@@ -3,6 +3,7 @@ QBCore.Config = QBConfig
 QBCore.Shared = QBShared
 QBCore.ClientCallbacks = {}
 QBCore.ServerCallbacks = {}
+QBCore.ServerRPC = {}
 
 exports('GetCoreObject', function()
     return QBCore


### PR DESCRIPTION
## Description

It allows you to call methods on remote side and receive return values Registers new method that can be called from remote side. Retrieving values will become easier and faster

for example:

client side

```
function test()
    local account = QBCore.Functions.TriggerRpc("qb-test:server:test1")
    print(json.encode(account))
end
```

server side

```
QBCore.Functions.CreateCallback('qb-test:server:test1', function(source, cb)
    cb('all value run')
end)
```

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
