### PR TITLE
FIX: Special characters in player name causes SQL error

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -84,7 +84,7 @@ function QBCore.Player.CheckPlayerData(source, PlayerData)
     if source then
         PlayerData.source = source
         PlayerData.license = PlayerData.license or QBCore.Functions.GetIdentifier(source, 'license')
-        PlayerData.name = GetPlayerName(source)
+        PlayerData.name = GetPlayerName(source):gsub("%W","")
         Offline = false
     end
 


### PR DESCRIPTION
## Description
Pull request updates PlayerData.name under server/player.lua line 87, and simply parses everything but alphanumeric.
This simply fixes a bug that causes a SQL error being thrown when players use steam name with special characters, such as "ꜱʜᴀᴅʏ𝘅"

## Checklist
- [x ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x ] My code fits the style guidelines.
- [ x] My PR fits the contribution guidelines.
