### PR TITLE
Feat: Add statebag for instances

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -180,6 +180,7 @@ end
 function QBCore.Functions.SetPlayerBucket(source, bucket)
     if source and bucket then
         local plicense = QBCore.Functions.GetIdentifier(source, 'license')
+        Player(source).state:set('instance', bucket, true)
         SetPlayerRoutingBucket(source, bucket)
         QBCore.Player_Buckets[plicense] = { id = source, bucket = bucket }
         return true


### PR DESCRIPTION
## Description
Currently there's no way to tell whenever your client switched routing bucket, and a getter for which routing bucket you are in. Therefor this PR aims to add a feature which is already present in other frameworks this will help developers to easier support for qb-core throughout scripts, which requires this.

Usage
```lua
local playerId = PlayerId()

AddStateBagChangeHandler('instance', ('player:%s'):format(playerId), function(_, _, bucket)
    print("You just entered bucket", bucket)
end)
```

## Checklist
- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
