### PR TITLE
Update functions.lua - PlayAnim

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -52,12 +52,55 @@ function QBCore.Functions.RequestAnimDict(animDict)
     end
 end
 
-function QBCore.Functions.PlayAnim(animDict, animName, upperbodyOnly, duration)
+-- Function to run an animation
+--- @param animDic string: The name of the animation dictionary
+--- @param animName string - The name of the animation within the dictionary
+--- @param duration number - The duration of the animation in milliseconds. -1 will play the animation indefinitely
+--- @param upperbodyOnly boolean - If true, the animation will only affect the upper body of the ped
+--- @return number - The timestamp indicating when the animation concluded. For animations set to loop indefinitely, this will still return the maximum duration of the animation.
+function QBCore.Functions.PlayAnim(animDict, animName, duration, upperbodyOnly)
+    -- local invoked = GetInvokingResource()
+    local invoked = 'runningAnim'
+    local animPromise = promise.new()
+    if type(animDict) ~= 'string' or type(animName) ~= 'string' then
+        animPromise:reject(invoked..' :^1  Wrong type for animDict or animName')
+        return animPromise.value
+    end
+    if not DoesAnimDictExist(animDict) then
+        animPromise:reject(invoked..' :^1  Animation dictionary does not exist')
+        return animPromise.value
+    end
+
     local flags = upperbodyOnly and 16 or 0
     local runTime = duration or -1
-    QBCore.Functions.RequestAnimDict(animDict)
-    TaskPlayAnim(PlayerPedId(), animDict, animName, 8.0, 1.0, runTime, flags, 0.0, false, false, true)
+    if runTime == -1 then flags = 49 end
+    local ped = PlayerPedId()
+    local start = GetGameTimer()
+    while not HasAnimDictLoaded(animDict) do
+        RequestAnimDict(animDict)
+        if (GetGameTimer() - start) > 5000 then
+            animPromise:reject(invoked..' :^1  Animation dictionary failed to load')
+            return animPromise.value
+        end
+        Wait(1)
+    end
+
+    TaskPlayAnim(ped, animDict, animName, 8.0, 8.0, runTime, flags, 0, true, true, true)
+    Wait(10) -- Wait a bit for the animation to start, then check if it exists
+    local currentTime = GetAnimDuration(animDict, animName)
+    if currentTime == 0 then
+        animPromise:reject(invoked..' :^1  Animation does not exist')
+        return animPromise.value
+    end
+
+    local fullDuration = currentTime * 1000
+    -- If duration is provided and is less than the full duration, use it instead
+    local waitTime = duration and math.min(duration, fullDuration) or fullDuration
+
+    Wait(waitTime)
     RemoveAnimDict(animDict)
+    animPromise:resolve(currentTime)
+    return animPromise.value
 end
 
 function QBCore.Functions.LoadModel(model)

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -58,9 +58,8 @@ end
 --- @param duration number - The duration of the animation in milliseconds. -1 will play the animation indefinitely
 --- @param upperbodyOnly boolean - If true, the animation will only affect the upper body of the ped
 --- @return number - The timestamp indicating when the animation concluded. For animations set to loop indefinitely, this will still return the maximum duration of the animation.
-function QBCore.Functions.PlayAnim(animDict, animName, duration, upperbodyOnly)
-    -- local invoked = GetInvokingResource()
-    local invoked = 'runningAnim'
+function QBCore.Functions.PlayAnim(animDict, animName, upperbodyOnly, duration)
+    local invoked = GetInvokingResource()
     local animPromise = promise.new()
     if type(animDict) ~= 'string' or type(animName) ~= 'string' then
         animPromise:reject(invoked..' :^1  Wrong type for animDict or animName')


### PR DESCRIPTION
The runningAnim function is designed to play a specific animation for a player's ped (character) in FiveM. Here's a detailed breakdown of what the function does:

The function takes four parameters: animDict (the name of the animation dictionary), animName (the name of the animation within the dictionary), duration (the duration of the animation in milliseconds), and upperbodyOnly (a boolean indicating whether the animation should only affect the upper body of the ped).

It starts by creating a new promise, animPromise, which will be used to handle the asynchronous nature of loading and playing the animation.

The function then checks if animDict and animName are strings. If not, it rejects the promise with an error message and returns.

It checks if the animation dictionary exists. If not, it rejects the promise with an error message and returns.

It sets the animation flags based on the upperbodyOnly parameter. If upperbodyOnly is true, the flags are set to 16, otherwise, they are set to 0. If the duration is -1 (indicating the animation should loop indefinitely), the flags are set to 49.

It gets the player's ped and the current game time.

It enters a loop where it requests the animation dictionary and waits until it's loaded. If the dictionary isn't loaded within 5 seconds, it rejects the promise with an error message and returns.

Once the animation dictionary is loaded, it plays the animation on the player's ped using TaskPlayAnim.

It waits for a short time to allow the animation to start, then gets the duration of the animation using GetAnimDuration.

If the animation duration is 0 (indicating the animation doesn't exist), it rejects the promise with an error message and returns.

It calculates the full duration of the animation in milliseconds and sets the wait time to the minimum of the provided duration and the full duration.

It waits for the duration of the animation, then removes the animation dictionary.

Finally, it resolves the promise with the current time, indicating when the animation concluded.