### PR TITLE
Update GetPlayerByLicense in player.lua

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -59,24 +59,14 @@ function QBCore.Player.GetOfflinePlayer(citizenid)
 end
 
 function QBCore.Player.GetPlayerByLicense(license)
-    if license then
-        local PlayerData = MySQL.prepare.await('SELECT * FROM players where license = ?', { license })
-        if PlayerData then
-            PlayerData.money = json.decode(PlayerData.money)
-            PlayerData.job = json.decode(PlayerData.job)
-            PlayerData.position = json.decode(PlayerData.position)
-            PlayerData.metadata = json.decode(PlayerData.metadata)
-            PlayerData.charinfo = json.decode(PlayerData.charinfo)
-            if PlayerData.gang then
-                PlayerData.gang = json.decode(PlayerData.gang)
-            else
-                PlayerData.gang = {}
-            end
+    if not license then return nil end
 
-            return QBCore.Player.CheckPlayerData(nil, PlayerData)
+    for k in next, QBCore.Players do
+        if QBCore.Players[k].PlayerData?.license == license then
+             return  QBCore.Players[k]
         end
     end
-    return nil
+    return nil    
 end
 
 function QBCore.Player.CheckPlayerData(source, PlayerData)


### PR DESCRIPTION
The function as previously implemented did not make sense, since the user can have more than one character, and it would always only return the first record found by the license. Instead, search to see if any player is online and has the license specified in the search.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [ X] My code fits the style guidelines.
- [ X] My PR fits the contribution guidelines.
