### PR TITLE
Fixed missing return statement in Player.Functions.HasItem

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -275,7 +275,7 @@ function QBCore.Player.CreatePlayer(PlayerData, Offline)
     end
 
     function self.Functions.HasItem(items, amount)
-        QBCore.Functions.HasItem(self.PlayerData.source, items, amount)
+        return QBCore.Functions.HasItem(self.PlayerData.source, items, amount)
     end
 
     function self.Functions.SetJobDuty(onDuty)


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

`self.Functions.HasItem` calls `QBCore.Functions.HasItem`, but does not return any value due to a missing return statement. 

I added the return statement so the function can be called from the Player Object instead of having to resort to calling `QBCore.Function.HasItem` and passing the source manually
## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
