### PR TITLE
Fix: Set job boss value to grade value

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -146,6 +146,7 @@ function QBCore.Player.CreatePlayer(PlayerData, Offline)
             self.PlayerData.job.grade.level = tonumber(gradeKey)
             self.PlayerData.job.grade.payment = jobGradeInfo.payment
             self.PlayerData.job.grade.isboss = jobGradeInfo.isboss or false
+            self.PlayerData.job.isboss = jobGradeInfo.isboss or false
         end
 
         if not self.Offline then
@@ -176,6 +177,7 @@ function QBCore.Player.CreatePlayer(PlayerData, Offline)
             self.PlayerData.gang.grade.name = gangGradeInfo.name
             self.PlayerData.gang.grade.level = tonumber(gradeKey)
             self.PlayerData.gang.grade.isboss = gangGradeInfo.isboss or false
+            self.PlayerData.gang.isboss = gangGradeInfo.isboss or false
         end
 
         if not self.Offline then


### PR DESCRIPTION
## Description

Updates the job and gang table's `isboss` value based on the grade.
This fixes the issue of not being able to open boss menus due to boss menus checking the isboss value.

## Checklist

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
