### PR TITLE
Fix typo.lua

### DIFF
--- a/shared/items.lua
+++ b/shared/items.lua
@@ -366,7 +366,7 @@ QBShared.Items = {
     dendrogyra_coral             = { name = 'dendrogyra_coral', label = 'Dendrogyra', weight = 1000, type = 'item', image = 'dendrogyra_coral.png', unique = false, useable = false, shouldClose = true, description = 'Its also known as pillar coral' },
     antipatharia_coral           = { name = 'antipatharia_coral', label = 'Antipatharia', weight = 1000, type = 'item', image = 'antipatharia_coral.png', unique = false, useable = false, shouldClose = true, description = 'Its also known as black corals or thorn corals' },
     diving_gear                  = { name = 'diving_gear', label = 'Diving Gear', weight = 30000, type = 'item', image = 'diving_gear.png', unique = true, useable = true, shouldClose = true, description = 'An oxygen tank and a rebreather' },
-    diving_fill                  = { name = 'diving_fill', label = 'Diving Tube', weight = 3000, type = 'item', image = 'diving_tube.png', unique = true, useable = true, shouldClose = true, discription = 'An oxygen tube and a rebreather' },
+    diving_fill                  = { name = 'diving_fill', label = 'Diving Tube', weight = 3000, type = 'item', image = 'diving_tube.png', unique = true, useable = true, shouldClose = true, description = 'An oxygen tube and a rebreather' },
 
     -- Other Tools
     casinochips                  = { name = 'casinochips', label = 'Casino Chips', weight = 0, type = 'item', image = 'casinochips.png', unique = false, useable = false, shouldClose = false, description = 'Chips For Casino Gambling' },


### PR DESCRIPTION
diving_fill had "description" spelled as "discription"

## Description

Fixes typo,, preventing description showing

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ X] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [ X] My code fits the style guidelines.
- [ X] My PR fits the contribution guidelines.
