### PR TITLE
Deprecate client-side vehicle spawning function

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -121,24 +121,18 @@ end)
 RegisterNetEvent('QBCore:Command:SpawnVehicle', function(vehName)
     local ped = PlayerPedId()
     local hash = joaat(vehName)
-    local veh = GetVehiclePedIsUsing(ped)
     if not IsModelInCdimage(hash) then return end
-    RequestModel(hash)
-    while not HasModelLoaded(hash) do
-        Wait(0)
-    end
-
+    QBCore.Functions.LoadModel(hash)
     if IsPedInAnyVehicle(ped) then
-        SetEntityAsMissionEntity(veh, true, true)
-        DeleteVehicle(veh)
+        local currentVehicle = GetVehiclePedIsUsing(ped)
+        SetEntityAsMissionEntity(currentVehicle, true, true)
+        DeleteVehicle(currentVehicle)
     end
-
-    local vehicle = CreateVehicle(hash, GetEntityCoords(ped), GetEntityHeading(ped), true, false)
-    TaskWarpPedIntoVehicle(ped, vehicle, -1)
-    SetVehicleFuelLevel(vehicle, 100.0)
-    SetVehicleDirtLevel(vehicle, 0.0)
-    SetModelAsNoLongerNeeded(hash)
-    TriggerEvent('vehiclekeys:client:SetOwner', QBCore.Functions.GetPlate(vehicle))
+    QBCore.Functions.SpawnVehicle(hash, function(vehicle)
+        SetEntityHeading(vehicle, GetEntityHeading(ped))
+        SetVehicleDirtLevel(vehicle, 0.0)
+        TriggerEvent('vehiclekeys:client:SetOwner', QBCore.Functions.GetPlate(vehicle))
+    end, GetEntityCoords(ped), true, true)
 end)
 
 RegisterNetEvent('QBCore:Command:DeleteVehicle', function()

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -348,7 +348,7 @@ function QBCore.Functions.LoadModel(model)
     end
 end
 
-function QBCore.Functions.SpawnVehicle(model, cb, coords, isnetworked, teleportInto)
+function QBCore.Functions.SpawnVehicle(model, cb, coords, isNetworked, warp)
     local ped = PlayerPedId()
     model = type(model) == 'string' and joaat(model) or model
     if not IsModelInCdimage(model) then return end
@@ -357,17 +357,21 @@ function QBCore.Functions.SpawnVehicle(model, cb, coords, isnetworked, teleportI
     else
         coords = GetEntityCoords(ped)
     end
-    isnetworked = isnetworked == nil or isnetworked
+    isNetworked = isNetworked == nil or isNetworked
+    if isNetworked then 
+        print("^3[WARNING] Spawning networked vehicles on the client is deprecated. Please use the server-side callback function instead.^0") 
+    end
     QBCore.Functions.LoadModel(model)
-    local veh = CreateVehicle(model, coords.x, coords.y, coords.z, coords.w, isnetworked, false)
-    local netid = NetworkGetNetworkIdFromEntity(veh)
+    local veh = CreateVehicle(model, coords.x, coords.y, coords.z, coords.w, isNetworked, false)
     SetVehicleHasBeenOwnedByPlayer(veh, true)
-    SetNetworkIdCanMigrate(netid, true)
+    SetNetworkIdCanMigrate(VehToNet(veh), true)
     SetVehicleNeedsToBeHotwired(veh, false)
     SetVehRadioStation(veh, 'OFF')
     SetVehicleFuelLevel(veh, 100.0)
     SetModelAsNoLongerNeeded(model)
-    if teleportInto then TaskWarpPedIntoVehicle(PlayerPedId(), veh, -1) end
+    if warp then 
+        TaskWarpPedIntoVehicle(ped, veh, -1) 
+    end
     if cb then cb(veh) end
 end
 


### PR DESCRIPTION
## Description

Deprecate the client-side `SpawnVehicle` function for creating networked vehicles. This function is fine for spawning non-networked vehicles but shouldn't be used for anything else. We should encourage server-sided entity creation through given callbacks.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
