### PR TITLE
fix for allowing bank accounts to go insanely negative

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -8,7 +8,7 @@ QBConfig.StatusInterval = 5000                          -- how often to check hu
 QBConfig.Money = {}
 QBConfig.Money.MoneyTypes = { cash = 500, bank = 5000, crypto = 0 } -- type = startamount - Add or remove money types for your server (for ex. blackmoney = 0), remember once added it will not be removed from the database!
 QBConfig.Money.DontAllowMinus = { 'cash', 'crypto' }                -- Money that is not allowed going in minus
-QBConfig.Money.MinusLimit = 5000                                    -- The maximum amount you can be negative 
+QBConfig.Money.MinusLimit = -5000                                    -- The maximum amount you can be negative 
 QBConfig.Money.PayCheckTimeOut = 10                                 -- The time in minutes that it will give the paycheck
 QBConfig.Money.PayCheckSociety = false                              -- If true paycheck will come from the society account that the player is employed at, requires qb-management
 

--- a/config.lua
+++ b/config.lua
@@ -8,6 +8,7 @@ QBConfig.StatusInterval = 5000                          -- how often to check hu
 QBConfig.Money = {}
 QBConfig.Money.MoneyTypes = { cash = 500, bank = 5000, crypto = 0 } -- type = startamount - Add or remove money types for your server (for ex. blackmoney = 0), remember once added it will not be removed from the database!
 QBConfig.Money.DontAllowMinus = { 'cash', 'crypto' }                -- Money that is not allowed going in minus
+QBConfig.Money.MinusLimit = 5000                                    -- The maximum amount you can be negative 
 QBConfig.Money.PayCheckTimeOut = 10                                 -- The time in minutes that it will give the paycheck
 QBConfig.Money.PayCheckSociety = false                              -- If true paycheck will come from the society account that the player is employed at, requires qb-management
 

--- a/server/player.lua
+++ b/server/player.lua
@@ -341,7 +341,7 @@ function QBCore.Player.CreatePlayer(PlayerData, Offline)
                 end
             end
         end
-        if self.PlayerData.money[moneytype] - amount <= QBConfig.Money.MinusLimit then return false end
+        if self.PlayerData.money[moneytype] - amount < QBConfig.Money.MinusLimit then return false end
         self.PlayerData.money[moneytype] = self.PlayerData.money[moneytype] - amount
 
         if not self.Offline then

--- a/server/player.lua
+++ b/server/player.lua
@@ -341,6 +341,7 @@ function QBCore.Player.CreatePlayer(PlayerData, Offline)
                 end
             end
         end
+        if self.PlayerData.money[moneytype] - amount <= QBConfig.Money.MinusLimit then return false end
         self.PlayerData.money[moneytype] = self.PlayerData.money[moneytype] - amount
 
         if not self.Offline then

--- a/server/player.lua
+++ b/server/player.lua
@@ -341,7 +341,7 @@ function QBCore.Player.CreatePlayer(PlayerData, Offline)
                 end
             end
         end
-        if self.PlayerData.money[moneytype] - amount < QBConfig.Money.MinusLimit then return false end
+        if self.PlayerData.money[moneytype] - amount < QBCore.Config.Money.MinusLimit then return false end
         self.PlayerData.money[moneytype] = self.PlayerData.money[moneytype] - amount
 
         if not self.Offline then


### PR DESCRIPTION
## Description
currently bank is not in the Dont Allow Minus config option and there is no limit to being negative for the RemoveMoney function

this adds a Config option ( -5000 is the preset) and the RemoveMoney function will now check to see if removing money will leave you more than -5000 (or what someone sets it to) and if it will then it returns false, if not and they have enough then it continues with the rest of the function


<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Yes it fixes numerous exploits 

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x ] My code fits the style guidelines.
- [ x] My PR fits the contribution guidelines.
