### PR TITLE
Force tankHealth & oilLevel to be float values to fix leaking issue

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -566,7 +566,7 @@ function QBCore.Functions.SetVehicleProperties(vehicle, props)
             SetVehicleEngineHealth(vehicle, props.engineHealth + 0.0)
         end
         if props.tankHealth then
-            SetVehiclePetrolTankHealth(vehicle, props.tankHealth)
+            SetVehiclePetrolTankHealth(vehicle, props.tankHealth + 0.0)
         end
         if props.fuelLevel then
             SetVehicleFuelLevel(vehicle, props.fuelLevel + 0.0)
@@ -575,7 +575,7 @@ function QBCore.Functions.SetVehicleProperties(vehicle, props)
             SetVehicleDirtLevel(vehicle, props.dirtLevel + 0.0)
         end
         if props.oilLevel then
-            SetVehicleOilLevel(vehicle, props.oilLevel)
+            SetVehicleOilLevel(vehicle, props.oilLevel + 0.0)
         end
         if props.color1 then
             if type(props.color1) == 'number' then


### PR DESCRIPTION
## Description

We are getting a lot of reports of issues with fuel leaking especially; this seems to be due to `SetVehicleProperties` not forcing these values to be a float. Some scripts may write to the vehicle props JSON directly and set the float fuelTankHealth to an integer value of 1000, and people are incorrectly blaming QBCore for this.

These changes will safeguard players from this potential issue.

You can replicate this easily yourself by running the following - your car will instantly start leaking fuel. This doesn't happen when running the same code with the value `1000.0` instead of `1000`.

```lua
local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
SetVehiclePetrolTankHealth(vehicle, 1000)
```

## Checklist

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
