### PR TITLE
Omitir esta solicitud, no s epor que razon estaba f620 de marca nissan en qb-vehicleshop/ shared/vehicles.lua desde su repositorio directamente y me estaba generando interferencia en la cecion de un mapeado de concecionario y la integracion del mismo vehiculo en cuestion

### DIFF
--- a/shared/vehicles.lua
+++ b/shared/vehicles.lua
@@ -114,7 +114,7 @@ local Vehicles = {
     --- Coupes (3)
     { model = 'cogcabrio',       name = 'Cognoscenti Cabrio',            brand = 'Enus',            price = 30000,   category = 'coupes',         type = 'automobile', shop = 'pdm' },
     { model = 'exemplar',        name = 'Exemplar',                      brand = 'Dewbauchee',      price = 40000,   category = 'coupes',         type = 'automobile', shop = 'pdm' },
-    { model = 'f620',            name = 'F620',                          brand = 'Ocelot',          price = 32500,   category = 'coupes',         type = 'automobile', shop = 'pdm' },
+    { model = 'rhapsody',        name = 'Rhapsody',                          brand = 'Ocelot',          price = 32500,   category = 'coupes',         type = 'automobile', shop = 'pdm' },
     { model = 'felon',           name = 'Felon',                         brand = 'Lampadati',       price = 31000,   category = 'coupes',         type = 'automobile', shop = 'pdm' },
     { model = 'felon2',          name = 'Felon GT',                      brand = 'Lampadati',       price = 37000,   category = 'coupes',         type = 'automobile', shop = 'pdm' },
     { model = 'jackal',          name = 'Jackal',                        brand = 'Ocelot',          price = 19000,   category = 'coupes',         type = 'automobile', shop = 'pdm' },


### PR DESCRIPTION
Omitir esta solicitud, no se por que razon estaba f620 de marca nissan en qb-vehicleshop/ shared/vehicles.lua desde su repositorio directamente y me estaba generando interferencia en la cecion de un mapeado de concecionario y la integracion del mismo vehiculo en cuestion