### PR TITLE
Allow Specific rockstar license holders to join even if the duplicate license check is enabled

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -113,6 +113,13 @@ QBConfig.Server.WhitelistPermission = 'admin'           -- Permission that's abl
 QBConfig.Server.PVP = true                              -- Enable or disable pvp on the server (Ability to shoot other players)
 QBConfig.Server.Discord = ''                            -- Discord invite link
 QBConfig.Server.CheckDuplicateLicense = true            -- Check for duplicate rockstar license on join
+QBConfig.Server.ExceptionalLicenses = {                 -- If enabled, it will not check if these specified licenses are duplicate(if you want shared account players to be able to play in your server)
+    enabled = true,
+    licences = {
+        'license:b2de9ea8f669f4de25d05b6fac17b4ae6f645032',
+        'license:c5891bbe326c6723d5476c3378fff6495f7bc998'
+    }
+}
 QBConfig.Server.Permissions = { 'god', 'admin', 'mod' } -- Add as many groups as you want here after creating them in your server.cfg
 
 QBConfig.Commands = {}                                  -- Command Configuration

--- a/server/events.lua
+++ b/server/events.lua
@@ -1,6 +1,6 @@
 -- Event Handler
-
 local isExceptional = false
+
 
 AddEventHandler('chatMessage', function(_, _, message)
     if string.sub(message, 1, 1) == '/' then
@@ -46,6 +46,7 @@ if readyFunction ~= nil then
 end
 
 local function onPlayerConnecting(name, _, deferrals)
+    isExceptional = false
     local src = source
     deferrals.defer()
 

--- a/server/events.lua
+++ b/server/events.lua
@@ -1,5 +1,7 @@
 -- Event Handler
 
+local isExceptional = false
+
 AddEventHandler('chatMessage', function(_, _, message)
     if string.sub(message, 1, 1) == '/' then
         CancelEvent()

--- a/server/events.lua
+++ b/server/events.lua
@@ -69,8 +69,22 @@ local function onPlayerConnecting(name, _, deferrals)
 
     if not license then
         return deferrals.done(Lang:t('error.no_valid_license'))
-    elseif QBCore.Config.Server.CheckDuplicateLicense and QBCore.Functions.IsLicenseInUse(license) then
-        return deferrals.done(Lang:t('error.duplicate_license'))
+    elseif QBCore.Config.Server.CheckDuplicateLicense then
+        if QBCore.Functions.IsLicenseInUse(license) then
+            if QBCore.Config.Server.ExceptionalLicenses.enabled then
+                for _, v in pairs(QBCore.Config.Server.ExceptionalLicenses.licences) do
+                    if license == v then
+                        isExceptional = true
+                        break
+                    end
+                end
+                if not isExceptional then
+                    return deferrals.done(Lang:t('error.duplicate_license'))
+                end
+            else
+                return deferrals.done(Lang:t('error.duplicate_license'))
+            end
+        end
     end
 
     Wait(0)


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Enhanced duplicate license check functionality by allowing specific Rockstar license holders to bypass the check when enabled. Added support for configurable exceptional licenses in ``QBConfig.Server.ExceptionalLicenses``

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
