### PR TITLE
Fix Armor not saving on player exit

### DIFF
--- a/server/events.lua
+++ b/server/events.lua
@@ -9,10 +9,12 @@ end)
 
 AddEventHandler('playerDropped', function(reason)
     local src = source
+    local ped = GetPlayerPed(src)
+    local armor = GetPedArmour(ped)
     if not QBCore.Players[src] then return end
     local Player = QBCore.Players[src]
-    TriggerEvent('qb-log:server:CreateLog', 'joinleave', 'Dropped', 'red', '**' .. GetPlayerName(src) .. '** (' .. Player.PlayerData.license .. ') left..' .. '\n **Reason:** ' .. reason)
-    TriggerEvent('QBCore:Server:PlayerDropped', Player)
+    TriggerEvent('qb-log:server:CreateLog', 'joinleave', 'Dropped', 'red', '**' .. GetPlayerName(src) .. '** (' .. Player.PlayerData.license .. ') left..' ..'\n **Reason:** ' .. reason)
+    Player.Functions.SetMetaData('armor', armor)
     Player.Functions.Save()
     QBCore.Player_Buckets[Player.PlayerData.license] = nil
     QBCore.Players[src] = nil


### PR DESCRIPTION
This PR introduces a feature to save a player's armor when exiting the server. This ensures player stats are preserved and improves the overall gameplay experience.  

In addition, I have also submitted a related PR on the **qb-ambulancejob** repository with complementary changes. Please approve the **qb-ambulancejob** PR after merging this one to maintain compatibility and prevent potential breakdowns or inconsistencies.  

## Description  

<!-- This PR adds functionality to save a player's armor upon exiting the server, ensuring their stats persist between sessions. This update complements changes proposed in the qb-ambulancejob PR to avoid potential compatibility issues. -->  

## Checklist  

<!-- Put an x inside the [ ] to check an item, like so: [x] -->  

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.  
- [x] My code fits the style guidelines.  
- [x] My PR fits the contribution guidelines. 