### PR TITLE
feat: use promises in callbacks + cleanup

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -208,7 +208,9 @@ end)
 
 -- Client Callback
 RegisterNetEvent('QBCore:Client:TriggerClientCallback', function(name, ...)
-    QBCore.Functions.TriggerClientCallback(name, function(...)
+    if not QBCore.ClientCallbacks[name] then return end
+
+    QBCore.ClientCallbacks[name](function(...)
         TriggerServerEvent('QBCore:Server:TriggerClientCallback', name, ...)
     end, ...)
 end)
@@ -216,7 +218,12 @@ end)
 -- Server Callback
 RegisterNetEvent('QBCore:Client:TriggerCallback', function(name, ...)
     if QBCore.ServerCallbacks[name] then
-        QBCore.ServerCallbacks[name](...)
+        QBCore.ServerCallbacks[name].promise:resolve(...)
+
+        if QBCore.ServerCallbacks[name].callback then
+            QBCore.ServerCallbacks[name].callback(...)
+        end
+
         QBCore.ServerCallbacks[name] = nil
     end
 end)

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -10,18 +10,9 @@ function QBCore.Functions.TriggerCallback(name, ...)
     local cb = nil
     local args = { ... }
 
-    if type(args[1]) == "function" then
+    if QBCore.Shared.IsFunction(args[1]) then
         cb = args[1]
         table.remove(args, 1)
-    elseif type(args[1]) == "table" then
-        local _, err = pcall(function()
-            args[1]["__cfx_functionReferenc"] = args[1]["__cfx_functionReferenc"]
-        end)
-
-        if err and string.find(err, "Cannot index a funcref") then
-            cb = args[1]
-            table.remove(args, 1)
-        end
     end
 
     QBCore.ServerCallbacks[name] = {
@@ -191,8 +182,12 @@ function QBCore.Functions.Notify(text, texttype, length, icon)
     SendNUIMessage(message)
 end
 
-function QBCore.Functions.Progressbar(name, label, duration, useWhileDead, canCancel, disableControls, animation, prop, propTwo, onFinish, onCancel)
-    if GetResourceState('progressbar') ~= 'started' then error('progressbar needs to be started in order for QBCore.Functions.Progressbar to work') end
+function QBCore.Functions.Progressbar(name, label, duration, useWhileDead, canCancel, disableControls, animation, prop,
+                                      propTwo, onFinish, onCancel)
+    if GetResourceState('progressbar') ~= 'started' then
+        error(
+            'progressbar needs to be started in order for QBCore.Functions.Progressbar to work')
+    end
     exports['progressbar']:Progress({
         name = name:lower(),
         duration = duration,
@@ -977,7 +972,8 @@ function QBCore.Functions.StartParticleAtCoord(dict, ptName, looped, coords, rot
     SetPtfxAssetNextCall(dict)
     local particleHandle
     if looped then
-        particleHandle = StartParticleFxLoopedAtCoord(ptName, coords.x, coords.y, coords.z, rot.x, rot.y, rot.z, scale or 1.0)
+        particleHandle = StartParticleFxLoopedAtCoord(ptName, coords.x, coords.y, coords.z, rot.x, rot.y, rot.z,
+            scale or 1.0)
         if color then
             SetParticleFxLoopedColour(particleHandle, color.r, color.g, color.b, false)
         end
@@ -996,7 +992,8 @@ function QBCore.Functions.StartParticleAtCoord(dict, ptName, looped, coords, rot
     return particleHandle
 end
 
-function QBCore.Functions.StartParticleOnEntity(dict, ptName, looped, entity, bone, offset, rot, scale, alpha, color, evolution, duration)
+function QBCore.Functions.StartParticleOnEntity(dict, ptName, looped, entity, bone, offset, rot, scale, alpha, color,
+                                                evolution, duration)
     QBCore.Functions.LoadParticleDictionary(dict)
     UseParticleFxAssetNextCall(dict)
     local particleHandle, boneID
@@ -1007,9 +1004,11 @@ function QBCore.Functions.StartParticleOnEntity(dict, ptName, looped, entity, bo
     end
     if looped then
         if bone then
-            particleHandle = StartParticleFxLoopedOnEntityBone(ptName, entity, offset.x, offset.y, offset.z, rot.x, rot.y, rot.z, boneID, scale)
+            particleHandle = StartParticleFxLoopedOnEntityBone(ptName, entity, offset.x, offset.y, offset.z, rot.x, rot
+                .y, rot.z, boneID, scale)
         else
-            particleHandle = StartParticleFxLoopedOnEntity(ptName, entity, offset.x, offset.y, offset.z, rot.x, rot.y, rot.z, scale)
+            particleHandle = StartParticleFxLoopedOnEntity(ptName, entity, offset.x, offset.y, offset.z, rot.x, rot.y,
+                rot.z, scale)
         end
         if evolution then
             SetParticleFxLoopedEvolution(particleHandle, evolution.name, evolution.amount, false)
@@ -1028,7 +1027,8 @@ function QBCore.Functions.StartParticleOnEntity(dict, ptName, looped, entity, bo
             SetParticleFxNonLoopedColour(color.r, color.g, color.b)
         end
         if bone then
-            StartParticleFxNonLoopedOnPedBone(ptName, entity, offset.x, offset.y, offset.z, rot.x, rot.y, rot.z, boneID, scale)
+            StartParticleFxNonLoopedOnPedBone(ptName, entity, offset.x, offset.y, offset.z, rot.x, rot.y, rot.z, boneID,
+                scale)
         else
             StartParticleFxNonLoopedOnEntity(ptName, entity, offset.x, offset.y, offset.z, rot.x, rot.y, rot.z, scale)
         end
@@ -1092,7 +1092,8 @@ end
 
 function QBCore.Functions.GetGroundHash(entity)
     local coords = GetEntityCoords(entity)
-    local num = StartShapeTestCapsule(coords.x, coords.y, coords.z + 4, coords.x, coords.y, coords.z - 2.0, 1, 1, entity, 7)
+    local num = StartShapeTestCapsule(coords.x, coords.y, coords.z + 4, coords.x, coords.y, coords.z - 2.0, 1, 1, entity,
+        7)
     local retval, success, endCoords, surfaceNormal, materialHash, entityHit = GetShapeTestResultEx(num)
     return materialHash, entityHit, surfaceNormal, endCoords, success, retval
 end

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -182,12 +182,8 @@ function QBCore.Functions.Notify(text, texttype, length, icon)
     SendNUIMessage(message)
 end
 
-function QBCore.Functions.Progressbar(name, label, duration, useWhileDead, canCancel, disableControls, animation, prop,
-                                      propTwo, onFinish, onCancel)
-    if GetResourceState('progressbar') ~= 'started' then
-        error(
-            'progressbar needs to be started in order for QBCore.Functions.Progressbar to work')
-    end
+function QBCore.Functions.Progressbar(name, label, duration, useWhileDead, canCancel, disableControls, animation, prop, propTwo, onFinish, onCancel)
+    if GetResourceState('progressbar') ~= 'started' then error('progressbar needs to be started in order for QBCore.Functions.Progressbar to work') end
     exports['progressbar']:Progress({
         name = name:lower(),
         duration = duration,
@@ -972,8 +968,7 @@ function QBCore.Functions.StartParticleAtCoord(dict, ptName, looped, coords, rot
     SetPtfxAssetNextCall(dict)
     local particleHandle
     if looped then
-        particleHandle = StartParticleFxLoopedAtCoord(ptName, coords.x, coords.y, coords.z, rot.x, rot.y, rot.z,
-            scale or 1.0)
+        particleHandle = StartParticleFxLoopedAtCoord(ptName, coords.x, coords.y, coords.z, rot.x, rot.y, rot.z, scale or 1.0)
         if color then
             SetParticleFxLoopedColour(particleHandle, color.r, color.g, color.b, false)
         end
@@ -992,8 +987,7 @@ function QBCore.Functions.StartParticleAtCoord(dict, ptName, looped, coords, rot
     return particleHandle
 end
 
-function QBCore.Functions.StartParticleOnEntity(dict, ptName, looped, entity, bone, offset, rot, scale, alpha, color,
-                                                evolution, duration)
+function QBCore.Functions.StartParticleOnEntity(dict, ptName, looped, entity, bone, offset, rot, scale, alpha, color, evolution, duration)
     QBCore.Functions.LoadParticleDictionary(dict)
     UseParticleFxAssetNextCall(dict)
     local particleHandle, boneID
@@ -1004,11 +998,9 @@ function QBCore.Functions.StartParticleOnEntity(dict, ptName, looped, entity, bo
     end
     if looped then
         if bone then
-            particleHandle = StartParticleFxLoopedOnEntityBone(ptName, entity, offset.x, offset.y, offset.z, rot.x, rot
-                .y, rot.z, boneID, scale)
+            particleHandle = StartParticleFxLoopedOnEntityBone(ptName, entity, offset.x, offset.y, offset.z, rot.x, rot.y, rot.z, boneID, scale)
         else
-            particleHandle = StartParticleFxLoopedOnEntity(ptName, entity, offset.x, offset.y, offset.z, rot.x, rot.y,
-                rot.z, scale)
+            particleHandle = StartParticleFxLoopedOnEntity(ptName, entity, offset.x, offset.y, offset.z, rot.x, rot.y, rot.z, scale)
         end
         if evolution then
             SetParticleFxLoopedEvolution(particleHandle, evolution.name, evolution.amount, false)
@@ -1027,8 +1019,7 @@ function QBCore.Functions.StartParticleOnEntity(dict, ptName, looped, entity, bo
             SetParticleFxNonLoopedColour(color.r, color.g, color.b)
         end
         if bone then
-            StartParticleFxNonLoopedOnPedBone(ptName, entity, offset.x, offset.y, offset.z, rot.x, rot.y, rot.z, boneID,
-                scale)
+            StartParticleFxNonLoopedOnPedBone(ptName, entity, offset.x, offset.y, offset.z, rot.x, rot.y, rot.z, boneID, scale)
         else
             StartParticleFxNonLoopedOnEntity(ptName, entity, offset.x, offset.y, offset.z, rot.x, rot.y, rot.z, scale)
         end
@@ -1092,8 +1083,7 @@ end
 
 function QBCore.Functions.GetGroundHash(entity)
     local coords = GetEntityCoords(entity)
-    local num = StartShapeTestCapsule(coords.x, coords.y, coords.z + 4, coords.x, coords.y, coords.z - 2.0, 1, 1, entity,
-        7)
+    local num = StartShapeTestCapsule(coords.x, coords.y, coords.z + 4, coords.x, coords.y, coords.z - 2.0, 1, 1, entity, 7)
     local retval, success, endCoords, surfaceNormal, materialHash, entityHit = GetShapeTestResultEx(num)
     return materialHash, entityHit, surfaceNormal, endCoords, success, retval
 end

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -29,7 +29,7 @@ function QBCore.Functions.TriggerCallback(name, ...)
         promise = promise.new()
     }
 
-    TriggerServerEvent('QBCore:Server:TriggerCallback', name, ...)
+    TriggerServerEvent('QBCore:Server:TriggerCallback', name, table.unpack(args))
 
     if cb == nil then
         Citizen.Await(QBCore.ServerCallbacks[name].promise)

--- a/server/events.lua
+++ b/server/events.lua
@@ -32,7 +32,7 @@ local databaseConnected, bansTableExists = readyFunction == nil, readyFunction =
 if readyFunction ~= nil then
     MySQL.ready(function()
         databaseConnected = true
-    
+
         local DatabaseInfo = QBCore.Functions.GetDatabaseInfo()
         if not DatabaseInfo or not DatabaseInfo.exists then return end
 
@@ -125,15 +125,23 @@ end)
 -- Client Callback
 RegisterNetEvent('QBCore:Server:TriggerClientCallback', function(name, ...)
     if QBCore.ClientCallbacks[name] then
-        QBCore.ClientCallbacks[name](...)
+        QBCore.ClientCallbacks[name].promise:resolve(...)
+
+        if QBCore.ClientCallbacks[name].callback then
+            QBCore.ClientCallbacks[name].callback(...)
+        end
+
         QBCore.ClientCallbacks[name] = nil
     end
 end)
 
 -- Server Callback
 RegisterNetEvent('QBCore:Server:TriggerCallback', function(name, ...)
+    if not QBCore.ServerCallbacks[name] then return end
+
     local src = source
-    QBCore.Functions.TriggerCallback(name, src, function(...)
+
+    QBCore.ServerCallbacks[name](src, function(...)
         TriggerClientEvent('QBCore:Client:TriggerCallback', src, name, ...)
     end, ...)
 end)

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -399,26 +399,32 @@ function PaycheckInterval()
     if next(QBCore.Players) then
         for _, Player in pairs(QBCore.Players) do
             if Player then
-                local payment = QBShared.Jobs[Player.PlayerData.job.name]['grades'][tostring(Player.PlayerData.job.grade.level)].payment
+                local payment = QBShared.Jobs[Player.PlayerData.job.name]['grades']
+                    [tostring(Player.PlayerData.job.grade.level)].payment
                 if not payment then payment = Player.PlayerData.job.payment end
                 if Player.PlayerData.job and payment > 0 and (QBShared.Jobs[Player.PlayerData.job.name].offDutyPay or Player.PlayerData.job.onduty) then
                     if QBCore.Config.Money.PayCheckSociety then
                         local account = exports['qb-banking']:GetAccountBalance(Player.PlayerData.job.name)
                         if account ~= 0 then          -- Checks if player is employed by a society
                             if account < payment then -- Checks if company has enough money to pay society
-                                TriggerClientEvent('QBCore:Notify', Player.PlayerData.source, Lang:t('error.company_too_poor'), 'error')
+                                TriggerClientEvent('QBCore:Notify', Player.PlayerData.source,
+                                    Lang:t('error.company_too_poor'), 'error')
                             else
                                 Player.Functions.AddMoney('bank', payment, 'paycheck')
-                                exports['qb-banking']:RemoveMoney(Player.PlayerData.job.name, payment, 'Employee Paycheck')
-                                TriggerClientEvent('QBCore:Notify', Player.PlayerData.source, Lang:t('info.received_paycheck', { value = payment }))
+                                exports['qb-banking']:RemoveMoney(Player.PlayerData.job.name, payment,
+                                    'Employee Paycheck')
+                                TriggerClientEvent('QBCore:Notify', Player.PlayerData.source,
+                                    Lang:t('info.received_paycheck', { value = payment }))
                             end
                         else
                             Player.Functions.AddMoney('bank', payment, 'paycheck')
-                            TriggerClientEvent('QBCore:Notify', Player.PlayerData.source, Lang:t('info.received_paycheck', { value = payment }))
+                            TriggerClientEvent('QBCore:Notify', Player.PlayerData.source,
+                                Lang:t('info.received_paycheck', { value = payment }))
                         end
                     else
                         Player.Functions.AddMoney('bank', payment, 'paycheck')
-                        TriggerClientEvent('QBCore:Notify', Player.PlayerData.source, Lang:t('info.received_paycheck', { value = payment }))
+                        TriggerClientEvent('QBCore:Notify', Player.PlayerData.source,
+                            Lang:t('info.received_paycheck', { value = payment }))
                     end
                 end
             end
@@ -438,19 +444,11 @@ function QBCore.Functions.TriggerClientCallback(name, source, ...)
     local cb = nil
     local args = { ... }
 
-    if type(args[1]) == "function" then
+    if QBCore.Shared.IsFunction(args[1]) then
         cb = args[1]
         table.remove(args, 1)
-    elseif type(args[1]) == "table" then
-        local _, err = pcall(function()
-            args[1]["__cfx_functionReferenc"] = args[1]["__cfx_functionReferenc"]
-        end)
-
-        if err and string.find(err, "Cannot index a funcref") then
-            cb = args[1]
-            table.remove(args, 1)
-        end
     end
+
 
     QBCore.ClientCallbacks[name] = {
         callback = cb,
@@ -651,7 +649,12 @@ function QBCore.Functions.IsPlayerBanned(source)
     if not result then return false end
     if os.time() < result.expire then
         local timeTable = os.date('*t', tonumber(result.expire))
-        return true, 'You have been banned from the server:\n' .. result.reason .. '\nYour ban expires ' .. timeTable.day .. '/' .. timeTable.month .. '/' .. timeTable.year .. ' ' .. timeTable.hour .. ':' .. timeTable.min .. '\n'
+        return true,
+            'You have been banned from the server:\n' ..
+            result.reason ..
+            '\nYour ban expires ' ..
+            timeTable.day ..
+            '/' .. timeTable.month .. '/' .. timeTable.year .. ' ' .. timeTable.hour .. ':' .. timeTable.min .. '\n'
     else
         MySQL.query('DELETE FROM bans WHERE id = ?', { result.id })
     end
@@ -732,7 +735,8 @@ function QBCore.Functions.PrepForSQL(source, data, pattern)
     local player = QBCore.Functions.GetPlayer(src)
     local result = string.match(data, pattern)
     if not result or string.len(result) ~= string.len(data) then
-        TriggerEvent('qb-log:server:CreateLog', 'anticheat', 'SQL Exploit Attempted', 'red', string.format('%s attempted to exploit SQL!', player.PlayerData.license))
+        TriggerEvent('qb-log:server:CreateLog', 'anticheat', 'SQL Exploit Attempted', 'red',
+            string.format('%s attempted to exploit SQL!', player.PlayerData.license))
         return false
     end
     return true

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -434,9 +434,35 @@ end
 ---@param source any
 ---@param cb function
 ---@param ... any
-function QBCore.Functions.TriggerClientCallback(name, source, cb, ...)
-    QBCore.ClientCallbacks[name] = cb
+function QBCore.Functions.TriggerClientCallback(name, source, ...)
+    local cb = nil
+    local args = { ... }
+
+    if type(args[1]) == "function" then
+        cb = args[1]
+        table.remove(args, 1)
+    elseif type(args[1]) == "table" then
+        local _, err = pcall(function()
+            args[1]["__cfx_functionReferenc"] = args[1]["__cfx_functionReferenc"]
+        end)
+
+        if err and string.find(err, "Cannot index a funcref") then
+            cb = args[1]
+            table.remove(args, 1)
+        end
+    end
+
+    QBCore.ClientCallbacks[name] = {
+        callback = cb,
+        promise = promise.new()
+    }
+
     TriggerClientEvent('QBCore:Client:TriggerClientCallback', source, name, ...)
+
+    if cb == nil then
+        Citizen.Await(QBCore.ClientCallbacks[name].promise)
+        return QBCore.ClientCallbacks[name].promise.value
+    end
 end
 
 ---Create Server Callback
@@ -444,16 +470,6 @@ end
 ---@param cb function
 function QBCore.Functions.CreateCallback(name, cb)
     QBCore.ServerCallbacks[name] = cb
-end
-
----Trigger Serv er Callback
----@param name string
----@param source any
----@param cb function
----@param ... any
-function QBCore.Functions.TriggerCallback(name, source, cb, ...)
-    if not QBCore.ServerCallbacks[name] then return end
-    QBCore.ServerCallbacks[name](source, cb, ...)
 end
 
 -- Items
@@ -475,7 +491,7 @@ function QBCore.Functions.CreateUseableItem(item, data)
     elseif type(data) == "function" then
         rawFunc = data
     end
-    
+
     if rawFunc then
         QBCore.UsableItems[item] = {
             func = rawFunc,

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -457,7 +457,7 @@ function QBCore.Functions.TriggerClientCallback(name, source, ...)
         promise = promise.new()
     }
 
-    TriggerClientEvent('QBCore:Client:TriggerClientCallback', source, name, ...)
+    TriggerClientEvent('QBCore:Client:TriggerClientCallback', source, name, table.unpack(args))
 
     if cb == nil then
         Citizen.Await(QBCore.ClientCallbacks[name].promise)

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -399,32 +399,26 @@ function PaycheckInterval()
     if next(QBCore.Players) then
         for _, Player in pairs(QBCore.Players) do
             if Player then
-                local payment = QBShared.Jobs[Player.PlayerData.job.name]['grades']
-                    [tostring(Player.PlayerData.job.grade.level)].payment
+                local payment = QBShared.Jobs[Player.PlayerData.job.name]['grades'][tostring(Player.PlayerData.job.grade.level)].payment
                 if not payment then payment = Player.PlayerData.job.payment end
                 if Player.PlayerData.job and payment > 0 and (QBShared.Jobs[Player.PlayerData.job.name].offDutyPay or Player.PlayerData.job.onduty) then
                     if QBCore.Config.Money.PayCheckSociety then
                         local account = exports['qb-banking']:GetAccountBalance(Player.PlayerData.job.name)
                         if account ~= 0 then          -- Checks if player is employed by a society
                             if account < payment then -- Checks if company has enough money to pay society
-                                TriggerClientEvent('QBCore:Notify', Player.PlayerData.source,
-                                    Lang:t('error.company_too_poor'), 'error')
+                                TriggerClientEvent('QBCore:Notify', Player.PlayerData.source, Lang:t('error.company_too_poor'), 'error')
                             else
                                 Player.Functions.AddMoney('bank', payment, 'paycheck')
-                                exports['qb-banking']:RemoveMoney(Player.PlayerData.job.name, payment,
-                                    'Employee Paycheck')
-                                TriggerClientEvent('QBCore:Notify', Player.PlayerData.source,
-                                    Lang:t('info.received_paycheck', { value = payment }))
+                                exports['qb-banking']:RemoveMoney(Player.PlayerData.job.name, payment, 'Employee Paycheck')
+                                TriggerClientEvent('QBCore:Notify', Player.PlayerData.source, Lang:t('info.received_paycheck', { value = payment }))
                             end
                         else
                             Player.Functions.AddMoney('bank', payment, 'paycheck')
-                            TriggerClientEvent('QBCore:Notify', Player.PlayerData.source,
-                                Lang:t('info.received_paycheck', { value = payment }))
+                            TriggerClientEvent('QBCore:Notify', Player.PlayerData.source, Lang:t('info.received_paycheck', { value = payment }))
                         end
                     else
                         Player.Functions.AddMoney('bank', payment, 'paycheck')
-                        TriggerClientEvent('QBCore:Notify', Player.PlayerData.source,
-                            Lang:t('info.received_paycheck', { value = payment }))
+                        TriggerClientEvent('QBCore:Notify', Player.PlayerData.source, Lang:t('info.received_paycheck', { value = payment }))
                     end
                 end
             end
@@ -448,7 +442,6 @@ function QBCore.Functions.TriggerClientCallback(name, source, ...)
         cb = args[1]
         table.remove(args, 1)
     end
-
 
     QBCore.ClientCallbacks[name] = {
         callback = cb,
@@ -649,12 +642,7 @@ function QBCore.Functions.IsPlayerBanned(source)
     if not result then return false end
     if os.time() < result.expire then
         local timeTable = os.date('*t', tonumber(result.expire))
-        return true,
-            'You have been banned from the server:\n' ..
-            result.reason ..
-            '\nYour ban expires ' ..
-            timeTable.day ..
-            '/' .. timeTable.month .. '/' .. timeTable.year .. ' ' .. timeTable.hour .. ':' .. timeTable.min .. '\n'
+        return true, 'You have been banned from the server:\n' .. result.reason .. '\nYour ban expires ' .. timeTable.day .. '/' .. timeTable.month .. '/' .. timeTable.year .. ' ' .. timeTable.hour .. ':' .. timeTable.min .. '\n'
     else
         MySQL.query('DELETE FROM bans WHERE id = ?', { result.id })
     end
@@ -735,8 +723,7 @@ function QBCore.Functions.PrepForSQL(source, data, pattern)
     local player = QBCore.Functions.GetPlayer(src)
     local result = string.match(data, pattern)
     if not result or string.len(result) ~= string.len(data) then
-        TriggerEvent('qb-log:server:CreateLog', 'anticheat', 'SQL Exploit Attempted', 'red',
-            string.format('%s attempted to exploit SQL!', player.PlayerData.license))
+        TriggerEvent('qb-log:server:CreateLog', 'anticheat', 'SQL Exploit Attempted', 'red', string.format('%s attempted to exploit SQL!', player.PlayerData.license))
         return false
     end
     return true

--- a/shared/main.lua
+++ b/shared/main.lua
@@ -68,6 +68,19 @@ function QBShared.ChangeVehicleExtra(vehicle, extra, enable)
     end
 end
 
+function QBShared.IsFunction(value)
+    if type(value) == 'table' then
+        local success = pcall(function()
+            -- we just need to check if the table is indexable or not, this will simply return the error "cannot index a funcref"
+            return value.__cfx_functionReference
+        end)
+
+        return success
+    end
+
+    return type(value) == 'function'
+end
+
 function QBShared.SetDefaultVehicleExtras(vehicle, config)
     -- Clear Extras
     for i = 1, 20 do

--- a/shared/main.lua
+++ b/shared/main.lua
@@ -70,12 +70,7 @@ end
 
 function QBShared.IsFunction(value)
     if type(value) == 'table' then
-        local success = pcall(function()
-            -- we just need to check if the table is indexable or not, this will simply return the error "cannot index a funcref"
-            return value.__cfx_functionReference
-        end)
-
-        return success
+        return value.__cfx_functionReference ~= nil and type(value.__cfx_functionReference) == "string"
     end
 
     return type(value) == 'function'


### PR DESCRIPTION
## Description

This PR adds the usage of promises in our callbacks. Meaning we can now trigger callbacks in this manner:

```lua
local response = QBCore.Functions.TriggerCallback("CALLBACK NAME", 123, "test value")
```

Without loosing compatibility with the old format:

```lua
QBCore.Functions.TriggerCallback("CALLBACK NAME", function(response)

end, 123, "test value")
```

This also introduces the `QBCore.Shared.IsFunction` function, to check whether a value is a function **OR** a funcref!

~~Only thing I'm a bit unsure about here, would be the fact that functions become funcrefs, which cant be checked via `type()`, as they return `table` instead of `function`. The solution here is a bit hacky, but the only real "good" way would be the PR [fivem](https://github.com/citizenfx/fivem) and add some kind of function to check whether a value is a funcref or not.~~

## Checklist

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
