### PR TITLE
feat: Add function to load animation dictionary

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -956,6 +956,14 @@ function QBCore.Functions.LoadAnimSet(animSet)
     end
 end
 
+function QBCore.Functions.LoadAnimDictt(animDict)
+    if HasAnimDictLoaded(animDict) then return end
+    RequestAnimDict(animDict)
+    while not HasAnimDictLoaded(animDict) do
+        Wait(0)
+    end
+end
+
 function QBCore.Functions.LoadParticleDictionary(dictionary)
     if HasNamedPtfxAssetLoaded(dictionary) then return end
     RequestNamedPtfxAsset(dictionary)

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -956,7 +956,7 @@ function QBCore.Functions.LoadAnimSet(animSet)
     end
 end
 
-function QBCore.Functions.LoadAnimDictt(animDict)
+function QBCore.Functions.LoadAnimDict(animDict)
     if HasAnimDictLoaded(animDict) then return end
     RequestAnimDict(animDict)
     while not HasAnimDictLoaded(animDict) do

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -957,6 +957,7 @@ function QBCore.Functions.LoadAnimSet(animSet)
 end
 
 function QBCore.Functions.LoadAnimDict(animDict)
+    if not DoesAnimDictExist(animDict) then return print(("^1ANIMDICT^7 %s does not exist"):format(animDict)) end
     if HasAnimDictLoaded(animDict) then return end
     RequestAnimDict(animDict)
     while not HasAnimDictLoaded(animDict) do

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -880,14 +880,6 @@ function QBCore.Functions.DrawText3D(x, y, z, text)
     ClearDrawOrigin()
 end
 
-function QBCore.Functions.RequestAnimDict(animDict)
-    if HasAnimDictLoaded(animDict) then return end
-    RequestAnimDict(animDict)
-    while not HasAnimDictLoaded(animDict) do
-        Wait(0)
-    end
-end
-
 function QBCore.Functions.GetClosestBone(entity, list)
     local playerCoords, bone, coords, distance = GetEntityCoords(PlayerPedId())
     for _, element in pairs(list) do
@@ -964,6 +956,9 @@ function QBCore.Functions.LoadAnimDict(animDict)
         Wait(0)
     end
 end
+
+-- backward compatibility
+QBCore.Functions.RequestAnimDict = QBCore.Functions.LoadAnimDict
 
 function QBCore.Functions.LoadParticleDictionary(dictionary)
     if HasNamedPtfxAssetLoaded(dictionary) then return end


### PR DESCRIPTION
## Description

Added function to load anim dict, there is already one to load anim set, why no this?

Update: Apparently there was QBCore.Functions.RequestAnimDict. The name doesn't fit the other "load" functions that exists in the core and also it does no check if the anim exists or not, so I will stick with the new and and add backward compatibility with the old name.

## Checklist

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
