### PR TITLE
Fixes misidentification of source as an identifier

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -45,8 +45,8 @@ end
 ---@param source any
 ---@return table
 function QBCore.Functions.GetPlayer(source)
-    if type(source) == 'number' then
-        return QBCore.Players[source]
+    if tonumber(source) ~= nil then -- If a number is a string ("1"), this will still correctly identify the index to use.
+        return QBCore.Players[tonumber(source)]
     else
         return QBCore.Players[QBCore.Functions.GetSource(source)]
     end


### PR DESCRIPTION
## Description

This fixes misidentification of string numbers (e.g. "1", "2", "3"), and correctly converts them to source numbers for indexing rather than interpreting it as an identifier.

## Checklist

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
