### PR TITLE
Added plate in for HasKeys parameter

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -164,7 +164,7 @@ RegisterNetEvent('QBCore:Client:VehicleInfo', function(info)
     local hasKeys = true
 
     if GetResourceState('qb-vehiclekeys') == 'started' then
-        hasKeys = exports['qb-vehiclekeys']:HasKeys()
+        hasKeys = exports['qb-vehiclekeys']:HasKeys(plate)
     end
 
     local data = {


### PR DESCRIPTION
## Description
Before it was returning nil and now atGetIn or inVeh or exiting it will trigger the plate and return true for the vehicle.
![image](https://github.com/user-attachments/assets/0145bd24-3896-41eb-8048-5730c15bd719)


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
