### PR TITLE
Add playerID feature to replace source ID

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -28,6 +28,7 @@ function QBCore.Functions.TriggerCallback(name, ...)
     end
 end
 
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Debug(resource, obj, depth)
     TriggerServerEvent('QBCore:DebugSomething', resource, obj, depth)
 end
@@ -39,11 +40,13 @@ function QBCore.Functions.GetPlayerData(cb)
     cb(QBCore.PlayerData)
 end
 
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Functions.GetCoords(entity)
     local coords = GetEntityCoords(entity)
     return vector4(coords.x, coords.y, coords.z, GetEntityHeading(entity))
 end
 
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Functions.HasItem(items, amount)
     return exports['qb-inventory']:HasItem(items, amount)
 end
@@ -105,7 +108,7 @@ function QBCore.Functions.LookAtEntity(entity, timeout, speed)
 end
 
 -- Function to run an animation
---- @param animDic string: The name of the animation dictionary
+--- @param animDict string: The name of the animation dictionary
 --- @param animName string - The name of the animation within the dictionary
 --- @param duration number - The duration of the animation in milliseconds. -1 will play the animation indefinitely
 --- @param upperbodyOnly boolean - If true, the animation will only affect the upper body of the ped
@@ -167,7 +170,7 @@ function QBCore.Functions.IsWearingGloves()
 end
 
 -- NUI Calls
-
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Functions.Notify(text, texttype, length, icon)
     local message = {
         action = 'notify',
@@ -224,6 +227,7 @@ function QBCore.Functions.GetObjects()
     return GetGamePool('CObject')
 end
 
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Functions.GetPlayers()
     return GetActivePlayers()
 end
@@ -248,6 +252,7 @@ function QBCore.Functions.GetPlayersFromCoords(coords, distance)
     return closePlayers
 end
 
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Functions.GetClosestPlayer(coords)
     local ped = PlayerPedId()
     if coords then
@@ -288,6 +293,7 @@ function QBCore.Functions.GetPeds(ignoreList)
     return peds
 end
 
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Functions.GetClosestPed(coords, ignoreList)
     local ped = PlayerPedId()
     if coords then
@@ -311,6 +317,7 @@ function QBCore.Functions.GetClosestPed(coords, ignoreList)
     return closestPed, closestDistance
 end
 
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Functions.GetClosestVehicle(coords)
     local ped = PlayerPedId()
     local vehicles = GetGamePool('CVehicle')
@@ -333,6 +340,7 @@ function QBCore.Functions.GetClosestVehicle(coords)
     return closestVehicle, closestDistance
 end
 
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Functions.GetClosestObject(coords)
     local ped = PlayerPedId()
     local objects = GetGamePool('CObject')
@@ -364,6 +372,7 @@ function QBCore.Functions.LoadModel(model)
     end
 end
 
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Functions.SpawnVehicle(model, cb, coords, isnetworked, teleportInto)
     local ped = PlayerPedId()
     model = type(model) == 'string' and joaat(model) or model

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -220,7 +220,7 @@ end, 'admin')
 -- Money
 
 QBCore.Commands.Add('givemoney', Lang:t('command.givemoney.help'), { { name = Lang:t('command.givemoney.params.id.name'), help = Lang:t('command.givemoney.params.id.help') }, { name = Lang:t('command.givemoney.params.moneytype.name'), help = Lang:t('command.givemoney.params.moneytype.help') }, { name = Lang:t('command.givemoney.params.amount.name'), help = Lang:t('command.givemoney.params.amount.help') } }, true, function(source, args)
-    local Player = QBCore.Functions.GetPlayer(tonumber(args[1]))
+    local Player = QBCore.Functions.GetPlayerByPlayerId(tonumber(args[1]))
     if Player then
         Player.Functions.AddMoney(tostring(args[2]), tonumber(args[3]), 'Admin give money')
     else
@@ -229,7 +229,7 @@ QBCore.Commands.Add('givemoney', Lang:t('command.givemoney.help'), { { name = La
 end, 'admin')
 
 QBCore.Commands.Add('setmoney', Lang:t('command.setmoney.help'), { { name = Lang:t('command.setmoney.params.id.name'), help = Lang:t('command.setmoney.params.id.help') }, { name = Lang:t('command.setmoney.params.moneytype.name'), help = Lang:t('command.setmoney.params.moneytype.help') }, { name = Lang:t('command.setmoney.params.amount.name'), help = Lang:t('command.setmoney.params.amount.help') } }, true, function(source, args)
-    local Player = QBCore.Functions.GetPlayer(tonumber(args[1]))
+    local Player = QBCore.Functions.GetPlayerByPlayerId(tonumber(args[1]))
     if Player then
         Player.Functions.SetMoney(tostring(args[2]), tonumber(args[3]))
     else
@@ -245,7 +245,7 @@ QBCore.Commands.Add('job', Lang:t('command.job.help'), {}, false, function(sourc
 end, 'user')
 
 QBCore.Commands.Add('setjob', Lang:t('command.setjob.help'), { { name = Lang:t('command.setjob.params.id.name'), help = Lang:t('command.setjob.params.id.help') }, { name = Lang:t('command.setjob.params.job.name'), help = Lang:t('command.setjob.params.job.help') }, { name = Lang:t('command.setjob.params.grade.name'), help = Lang:t('command.setjob.params.grade.help') } }, true, function(source, args)
-    local Player = QBCore.Functions.GetPlayer(tonumber(args[1]))
+    local Player = QBCore.Functions.GetPlayerByPlayerId(tonumber(args[1]))
     if Player then
         Player.Functions.SetJob(tostring(args[2]), tonumber(args[3]))
     else
@@ -261,7 +261,7 @@ QBCore.Commands.Add('gang', Lang:t('command.gang.help'), {}, false, function(sou
 end, 'user')
 
 QBCore.Commands.Add('setgang', Lang:t('command.setgang.help'), { { name = Lang:t('command.setgang.params.id.name'), help = Lang:t('command.setgang.params.id.help') }, { name = Lang:t('command.setgang.params.gang.name'), help = Lang:t('command.setgang.params.gang.help') }, { name = Lang:t('command.setgang.params.grade.name'), help = Lang:t('command.setgang.params.grade.help') } }, true, function(source, args)
-    local Player = QBCore.Functions.GetPlayer(tonumber(args[1]))
+    local Player = QBCore.Functions.GetPlayerByPlayerId(tonumber(args[1]))
     if Player then
         Player.Functions.SetGang(tostring(args[2]), tonumber(args[3]))
     else

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -11,6 +11,7 @@ QBCore.UsableItems = {}
 ---Gets the coordinates of an entity
 ---@param entity number
 ---@return vector4
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Functions.GetCoords(entity)
     local coords = GetEntityCoords(entity, false)
     local heading = GetEntityHeading(entity)
@@ -19,7 +20,7 @@ end
 
 ---Gets player identifier of the given type
 ---@param source any
----@param idtype string
+---@param idtype? string
 ---@return string?
 function QBCore.Functions.GetIdentifier(source, idtype)
     if GetConvarInt('sv_fxdkMode', 0) == 1 then return 'license:fxdk' end
@@ -30,6 +31,7 @@ end
 ---@param identifier string
 ---@return number
 function QBCore.Functions.GetSource(identifier)
+    if not identifier then return 0 end
     for src, _ in pairs(QBCore.Players) do
         local idens = GetPlayerIdentifiers(src)
         for _, id in pairs(idens) do
@@ -45,6 +47,7 @@ end
 ---@param source any
 ---@return table
 function QBCore.Functions.GetPlayer(source)
+    if not source then return nil end
     if type(source) == 'number' then
         return QBCore.Players[source]
     else
@@ -56,8 +59,23 @@ end
 ---@param citizenid string
 ---@return table?
 function QBCore.Functions.GetPlayerByCitizenId(citizenid)
+    if not citizenid then return nil end
     for src in pairs(QBCore.Players) do
         if QBCore.Players[src].PlayerData.citizenid == citizenid then
+            return QBCore.Players[src]
+        end
+    end
+    return nil
+end
+
+---Get player by player id
+---@param playerid number
+---@return table?
+function QBCore.Functions.GetPlayerByPlayerId(playerid)
+    playerid = tonumber(playerid)
+    if not playerid then return nil end
+    for src in pairs(QBCore.Players) do
+        if QBCore.Players[src].PlayerData.playerid == playerid then
             return QBCore.Players[src]
         end
     end
@@ -118,6 +136,7 @@ end
 
 ---Get all players. Returns the server ids of all players.
 ---@return table
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Functions.GetPlayers()
     local sources = {}
     for k in pairs(QBCore.Players) do
@@ -169,6 +188,7 @@ end
 --- @param coords vector The coordinates to calculate the distance from. Can be a table with x, y, z fields or a vector3. If not provided, the source player's Ped's coordinates are used.
 --- @return string closestPlayer - The Player that is closest to the source player (or the provided coordinates). Returns -1 if no Players are found.
 --- @return number closestDistance - The distance to the closest Player. Returns -1 if no Players are found.
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Functions.GetClosestPlayer(source, coords)
     local ped = GetPlayerPed(source)
     local players = GetPlayers()
@@ -194,6 +214,7 @@ end
 --- @param coords vector The coordinates to calculate the distance from. Can be a table with x, y, z fields or a vector3. If not provided, the source player's Ped's coordinates are used.
 --- @return number closestObject - The Object that is closest to the source player (or the provided coordinates). Returns -1 if no Objects are found.
 --- @return number closestDistance - The distance to the closest Object. Returns -1 if no Objects are found.
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Functions.GetClosestObject(source, coords)
     local ped = GetPlayerPed(source)
     local objects = GetAllObjects()
@@ -215,6 +236,7 @@ end
 --- @param coords vector The coordinates to calculate the distance from. Can be a table with x, y, z fields or a vector3. If not provided, the source player's Ped's coordinates are used.
 --- @return number closestVehicle - The Vehicle that is closest to the source player (or the provided coordinates). Returns -1 if no Vehicles are found.
 --- @return number closestDistance - The distance to the closest Vehicle. Returns -1 if no Vehicles are found.
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Functions.GetClosestVehicle(source, coords)
     local ped = GetPlayerPed(source)
     local vehicles = GetAllVehicles()
@@ -236,6 +258,7 @@ end
 --- @param coords vector The coordinates to calculate the distance from. Can be a table with x, y, z fields or a vector3. If not provided, the source player's Ped's coordinates are used.
 --- @return number closestPed - The Ped that is closest to the source player (or the provided coordinates). Returns -1 if no Peds are found.
 --- @return number closestDistance - The distance to the closest Ped. Returns -1 if no Peds are found.
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Functions.GetClosestPed(source, coords)
     local ped = GetPlayerPed(source)
     local peds = GetAllPeds()
@@ -335,6 +358,7 @@ end
 ---@param coords vector
 ---@param warp boolean
 ---@return number
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Functions.SpawnVehicle(source, model, coords, warp)
     local ped = GetPlayerPed(source)
     model = type(model) == 'string' and joaat(model) or model
@@ -429,7 +453,6 @@ end
 ---Trigger Client Callback
 ---@param name string
 ---@param source any
----@param cb function
 ---@param ... any
 function QBCore.Functions.TriggerClientCallback(name, source, ...)
     local cb = nil
@@ -695,6 +718,7 @@ end
 ---@param items table|string
 ---@param amount number
 ---@return boolean
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Functions.HasItem(source, items, amount)
     if GetResourceState('qb-inventory') == 'missing' then return end
     return exports['qb-inventory']:HasItem(source, items, amount)
@@ -705,6 +729,7 @@ end
 ---@param text string
 ---@param type string
 ---@param length number
+---@diagnostic disable-next-line: duplicate-set-field
 function QBCore.Functions.Notify(source, text, type, length)
     TriggerClientEvent('QBCore:Notify', source, text, type, length)
 end


### PR DESCRIPTION
This feature hides the player's source ID and replaces it with a persistent playerID, ensuring that each player's ID remains the same across sessions. The goal is to use playerID instead of source in QB scripts when performing actions on a player.

For example, replacing `ban source` with `ban playerID` or `giveitem source` with `giveitem playerID`. This ensures that each player has a unique, sequentially increasing ID.

Last Note: Many qb scripts need to be edited to fully utilize this feature