### PR TITLE
Fix warning message by adding white color again

### DIFF
--- a/shared/locale.lua
+++ b/shared/locale.lua
@@ -102,7 +102,7 @@ function Locale:t(key, subs)
         -- At this point we know whether the phrase does not exist for this key
     else
         if self.warnOnMissing then
-            print(('^3Warning: Missing phrase for key: "%s"'):format(key))
+            print(('^3Warning: Missing phrase for key: "%s"^0'):format(key))
         end
         if self.fallback then
             return self.fallback:t(key, subs)


### PR DESCRIPTION
## Description

Fixed lang warning message. The current situations is the following:

![image](https://github.com/user-attachments/assets/8a6a8970-0b19-44fe-ac77-1709fd8c8a31)

The console messages after the warning of missing lang are yellow, when te expected behaviour is thta only the warning message is yellow. After adding `^0` after the msg, the bug is solved as shown now:

![image](https://github.com/user-attachments/assets/99389dac-7396-455f-bd04-5395b47c72b1)
 

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
