### PR TITLE
Cache common Identifiers for faster access

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -12,7 +12,7 @@ local playerIndices          = {
 }
 
 local function updatePlayerIdentifiers(player, oldData)
-    if oldData then
+    if not player and oldData then
         if oldData.citizenid then playerIndices.citizenid[oldData.citizenid] = nil end
         if oldData.license then playerIndices.license[oldData.license] = nil end
         if oldData.charinfo and oldData.charinfo.phone then playerIndices.phone[oldData.charinfo.phone] = nil end
@@ -51,10 +51,7 @@ AddEventHandler('QBCore:Server:OnPlayerUnload', function(source)
    if Player then
         local oldData = Player.PlayerData
         if playerIndices.citizenid[oldData.citizenid] then
-            if oldData.citizenid then playerIndices.citizenid[oldData.citizenid] = nil end
-            if oldData.license then playerIndices.license[oldData.license] = nil end
-            if oldData.charinfo and oldData.charinfo.phone then playerIndices.phone[oldData.charinfo.phone] = nil end
-            if oldData.charinfo and oldData.charinfo.account then playerIndices.account[oldData.charinfo.account] = nil end
+            updatePlayerIdentifiers(nil,oldData)
         end
    end
 end)


### PR DESCRIPTION
## Description

Cache the most common Identifiers so can be access more faster without for loops

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [X ] My code fits the style guidelines.
- [X ] My PR fits the contribution guidelines.
