### PR TITLE
Updated player deletion code to accommodate tables that do not use the column name citizenid

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -529,42 +529,65 @@ end
 
 -- Delete character
 
-local playertables = { -- Add tables as needed
-    { table = 'players' },
-    { table = 'apartments' },
-    { table = 'bank_accounts' },
-    { table = 'crypto_transactions' },
-    { table = 'phone_invoices' },
-    { table = 'phone_messages' },
-    { table = 'playerskins' },
-    { table = 'player_contacts' },
-    { table = 'player_houses' },
-    { table = 'player_mails' },
-    { table = 'player_outfits' },
-    { table = 'player_vehicles' }
+local playertables = { -- Add tables as needed 
+    ---
+    --- 'table' is the new SQL table name
+    --- 'key' is the column name which contains the 'citizenid'
+    --- 
+    --Tables where primary key = 'citizenid'
+    { table = 'players', key = 'citizenid' },
+    { table = 'apartments', key = 'citizenid' },
+    { table = 'bank_accounts', key = 'citizenid' },
+    { table = 'bank_statements', key = 'citizenid' },
+    { table = 'crypto_transactions', key = 'citizenid' },
+    { table = 'player_houses', key = 'citizenid' },
+    { table = 'player_outfits', key = 'citizenid' },
+    { table = 'player_vehicles', key = 'citizenid' },
+    { table = 'playerskins', key = 'citizenid' },
+
+    --Tables where primary key = 'cid'
+    { table = 'phone_invoices', key = 'cid' },
+    { table = 'phone_messages', key = 'cid' },
+
+     --Tables where primary key = 'identifier'
+    { table = 'player_contacts', key = 'identifier' },
+    { table = 'bank_cards', key = 'identifier' },
+    { table = 'bank_history', key = 'identifier' },
+    { table = 'casino_players', key = 'identifier' },
+    { table = 'cd_garage_privategarage', key = 'identifier' },
+    { table = 'inventory_clothes', key = 'identifier' },
+    { table = 'lation_detecting', key = 'identifier' },
+    { table = 'm_hunting', key = 'identifier' },
+    
+    --Tables with other citizenid labels
+    { table = 'bank_process',  key = 'owner' },
+    { table = 'mail_accounts', key = 'owner' },
+    { table = 'lation_chopshop', key = 'player_identifier' },
 }
 
 function QBCore.Player.DeleteCharacter(source, citizenid)
     local license = QBCore.Functions.GetIdentifier(source, 'license')
     local result = MySQL.scalar.await('SELECT license FROM players where citizenid = ?', { citizenid })
     if license == result then
-        local query = 'DELETE FROM %s WHERE citizenid = ?'
+        local query = 'DELETE FROM %s WHERE %s = ?'
         local tableCount = #playertables
         local queries = table.create(tableCount, 0)
 
         for i = 1, tableCount do
             local v = playertables[i]
-            queries[i] = { query = query:format(v.table), values = { citizenid } }
+            queries[i] = { query = query:format(v.table, v.key), values = { citizenid } }
         end
 
         MySQL.transaction(queries, function(result2)
             if result2 then
-                TriggerEvent('qb-log:server:CreateLog', 'joinleave', 'Character Deleted', 'red', '**' .. GetPlayerName(source) .. '** ' .. license .. ' deleted **' .. citizenid .. '**..')
+                TriggerEvent('qb-log:server:CreateLog', 'joinleave', 'Character Deleted', 'red',
+                    '**' .. GetPlayerName(source) .. '** ' .. license .. ' deleted **' .. citizenid .. '**..')
             end
         end)
     else
         DropPlayer(source, Lang:t('info.exploit_dropped'))
-        TriggerEvent('qb-log:server:CreateLog', 'anticheat', 'Anti-Cheat', 'white', GetPlayerName(source) .. ' Has Been Dropped For Character Deletion Exploit', true)
+        TriggerEvent('qb-log:server:CreateLog', 'anticheat', 'Anti-Cheat', 'white',
+            GetPlayerName(source) .. ' Has Been Dropped For Character Deletion Exploit', true)
     end
 end
 
@@ -581,12 +604,13 @@ function QBCore.Player.ForceDeleteCharacter(citizenid)
         end
         for i = 1, tableCount do
             local v = playertables[i]
-            queries[i] = { query = query:format(v.table), values = { citizenid } }
+            queries[i] = { query = query:format(v.table, v.key), values = { citizenid } }
         end
 
         MySQL.transaction(queries, function(result2)
             if result2 then
-                TriggerEvent('qb-log:server:CreateLog', 'joinleave', 'Character Force Deleted', 'red', 'Character **' .. citizenid .. '** got deleted')
+                TriggerEvent('qb-log:server:CreateLog', 'joinleave', 'Character Force Deleted', 'red',
+                    'Character **' .. citizenid .. '** got deleted')
             end
         end)
     end

--- a/server/player.lua
+++ b/server/player.lua
@@ -530,39 +530,25 @@ end
 -- Delete character
 
 local playertables = { -- Add tables as needed 
-    ---
     --- 'table' is the new SQL table name
     --- 'key' is the column name which contains the 'citizenid'
-    --- 
-    --Tables where primary key = 'citizenid'
+    
+    -- Tables where primary key = 'citizenid'    
     { table = 'players', key = 'citizenid' },
     { table = 'apartments', key = 'citizenid' },
     { table = 'bank_accounts', key = 'citizenid' },
-    { table = 'bank_statements', key = 'citizenid' },
     { table = 'crypto_transactions', key = 'citizenid' },
     { table = 'player_houses', key = 'citizenid' },
     { table = 'player_outfits', key = 'citizenid' },
     { table = 'player_vehicles', key = 'citizenid' },
     { table = 'playerskins', key = 'citizenid' },
+    { table = 'phone_invoices', key = 'citizenid' },
+    { table = 'phone_messages', key = 'citizenid' },
+    { table = 'player_contacts', key = 'citizenid' },
 
-    --Tables where primary key = 'cid'
-    { table = 'phone_invoices', key = 'cid' },
-    { table = 'phone_messages', key = 'cid' },
-
-     --Tables where primary key = 'identifier'
-    { table = 'player_contacts', key = 'identifier' },
-    { table = 'bank_cards', key = 'identifier' },
-    { table = 'bank_history', key = 'identifier' },
-    { table = 'casino_players', key = 'identifier' },
-    { table = 'cd_garage_privategarage', key = 'identifier' },
-    { table = 'inventory_clothes', key = 'identifier' },
-    { table = 'lation_detecting', key = 'identifier' },
-    { table = 'm_hunting', key = 'identifier' },
-    
-    --Tables with other citizenid labels
-    { table = 'bank_process',  key = 'owner' },
-    { table = 'mail_accounts', key = 'owner' },
-    { table = 'lation_chopshop', key = 'player_identifier' },
+    ---
+    --- Tables where primary key is not 'citizenid'
+    --- Example: { table = 'TABLE_NAME', key = 'CITIZEN_IDENTIFIER' },
 }
 
 function QBCore.Player.DeleteCharacter(source, citizenid)


### PR DESCRIPTION
Updated player deletion code in `server/player.lua` to accommodate tables that do not use the column name `citizenid`.
Many scripts use other column names to store the `citizenid` but contain data that should be deleted upon character deletion. This leads to excess data build up in the database that is no longer needed and currently requires manual effort to clean out the database.

New format for `playertables` now contains table and key variables (primary key column name)
and updated SQL commands in `DeleteCharacter` and `ForceDeleteCharacter` to handle variable column names

```
--- 'table' is the new SQL table name
--- 'key' is the column name which contains the 'citizenid'
{ table = 'players', key = 'citizenid' } 
```

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
