### PR TITLE
Semantic Version Bump 

### DIFF
--- a/.github/workflows/semantic-bump-version.yml
+++ b/.github/workflows/semantic-bump-version.yml
@@ -1,0 +1,75 @@
+name: Semantic Version Bump (Conventional Commits)
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  semver-bump:
+    runs-on: ubuntu-latest
+    if: github.event.head_commit.author.name != 'github-actions[bot]'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Determine bump type from commit message
+        id: bump
+        run: |
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          echo "🔍 Commit message: $COMMIT_MSG"
+
+          if echo "$COMMIT_MSG" | grep -qE 'BREAKING CHANGE|!:'; then
+            echo "bump=major" >> $GITHUB_OUTPUT
+          elif echo "$COMMIT_MSG" | grep -qE '^feat(\(.+\))?:'; then
+            echo "bump=minor" >> $GITHUB_OUTPUT
+          elif echo "$COMMIT_MSG" | grep -qE '^fix(\(.+\))?:'; then
+            echo "bump=patch" >> $GITHUB_OUTPUT
+          else
+            echo "bump=none" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Bump version in fxmanifest.lua
+        if: steps.bump.outputs.bump != 'none'
+        run: |
+          FILE="fxmanifest.lua"
+          VERSION_LINE=$(grep -E "version ['\"]?[0-9]+\.[0-9]+\.[0-9]+['\"]?" "$FILE")
+          VERSION=$(echo "$VERSION_LINE" | grep -oE "[0-9]+\.[0-9]+\.[0-9]+")
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+          case "${{ steps.bump.outputs.bump }}" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+
+          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+          sed -i "s/version ['\"]$VERSION['\"]/version '$NEW_VERSION'/" "$FILE"
+          echo "new_version=$NEW_VERSION" >> $GITHUB_ENV
+
+      - name: Commit and push version bump
+        if: steps.bump.outputs.bump != 'none'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add fxmanifest.lua
+
+          if git diff --cached --quiet; then
+            echo "⚠️ No version changes to commit."
+            exit 0
+          fi
+
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          git commit -m "ci: bump fxmanifest version to ${{ env.new_version }} – $COMMIT_MSG"
+          git push

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -733,6 +733,5 @@ for functionName, func in pairs(QBCore.Functions) do
         exports(functionName, func)
     end
 end
-
 -- Access a specific function directly:
 -- exports['qb-core']:Notify(source, 'Hello Player!')

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -7,7 +7,6 @@ QBCore.UsableItems = {}
 -- Get your player first and then trigger a function on them
 -- ex: local player = QBCore.Functions.GetPlayer(source)
 -- ex: local example = player.Functions.functionname(parameter)
-
 ---Gets the coordinates of an entity
 ---@param entity number
 ---@return vector4

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -394,7 +394,7 @@ function QBCore.Functions.CreateVehicle(source, model, vehtype, coords, warp)
 end
 
 function PaycheckInterval()
-    if not next(QBCore.Players) then 
+    if not next(QBCore.Players) then
         SetTimeout(QBCore.Config.Money.PayCheckTimeOut * (60 * 1000), PaycheckInterval) -- Prevent paychecks from stopping forever once 0 players
         return 
     end

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -396,7 +396,7 @@ end
 function PaycheckInterval()
     if not next(QBCore.Players) then
         SetTimeout(QBCore.Config.Money.PayCheckTimeOut * (60 * 1000), PaycheckInterval) -- Prevent paychecks from stopping forever once 0 players
-        return 
+        return
     end
     for _, Player in pairs(QBCore.Players) do
         if not Player then return end


### PR DESCRIPTION
Semantic Version Bump 

This GitHub Action automatically bumps the version in your `fxmanifest.lua` based on the commit message that triggered the push. It uses [Conventional Commits](https://www.conventionalcommits.org/) to determine whether to apply a **patch**, **minor**, or **major** version bump.

- The Action reads the current version from `fxmanifest.lua` (e.g. `version '1.3.0'`)
- It inspects the latest commit message:
  - `fix:` → bumps **PATCH**
  - `feat:` → bumps **MINOR**
  - `feat!:` or `BREAKING CHANGE:` → bumps **MAJOR**
- It writes the new version back into `fxmanifest.lua`
- Commits and pushes the updated version with the original commit message included