### PR TITLE
feat(core): add functions to retrieve online players by job name or type with optional on-duty check

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -150,6 +150,52 @@ function QBCore.Functions.GetPlayersOnDuty(job)
     return players, count
 end
 
+---Gets a list of all online players of a specified job and the number, with an option to check if they are on duty.
+---@param job string
+---@param checkOnDuty boolean
+---@return table, number
+function QBCore.Functions.GetPlayersByJobName(job, checkOnDuty)
+    local players = {}
+    local count = 0
+    for src, Player in pairs(QBCore.Players) do
+        if Player.PlayerData.job.name == job then
+            if checkOnDuty then
+                if Player.PlayerData.job.onduty then
+                    players[#players + 1] = src
+                    count += 1
+                end
+            else
+                players[#players + 1] = src
+                count += 1
+            end
+        end
+    end
+    return players, count
+end
+
+---Gets a list of all online players with a specified job type and the number, with an option to check if they are on duty.
+---@param jobType string
+---@param checkOnDuty boolean
+---@return table, number
+function QBCore.Functions.GetPlayersByJobType(jobType, checkOnDuty)
+    local players = {}
+    local count = 0
+    for src, Player in pairs(QBCore.Players) do
+        if Player.PlayerData.job.type == jobType then
+            if checkOnDuty then
+                if Player.PlayerData.job.onduty then
+                    players[#players + 1] = src
+                    count += 1
+                end
+            else
+                players[#players + 1] = src
+                count += 1
+            end
+        end
+    end
+    return players, count
+end
+
 ---Returns only the amount of players on duty for the specified job
 ---@param job string
 ---@return number

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -132,66 +132,34 @@ function QBCore.Functions.GetQBPlayers()
     return QBCore.Players
 end
 
+--- Gets a list of all online players of a specified job or job type and the number
+--- @param job string
+--- @param checkOnDuty boolean If true, only players on duty will be returned
+function QBCore.Functions.GetPlayersByJob(job, checkOnDuty)
+    local players = {}
+    local count = 0
+    for src, Player in pairs(QBCore.Players) do
+        local playerData = Player.PlayerData
+        if playerData.job.name == job or playerData.job.type == job then
+            if checkOnDuty then
+                if playerData.job.onduty then
+                    players[#players + 1] = src
+                    count += 1
+                end
+            else
+                players[#players + 1] = src
+                count += 1
+            end
+        end
+    end
+    return players, count
+end
+
 ---Gets a list of all on duty players of a specified job and the number
 ---@param job string
 ---@return table, number
 function QBCore.Functions.GetPlayersOnDuty(job)
-    local players = {}
-    local count = 0
-    for src, Player in pairs(QBCore.Players) do
-        if Player.PlayerData.job.name == job then
-            if Player.PlayerData.job.onduty then
-                players[#players + 1] = src
-                count += 1
-            end
-        end
-    end
-    return players, count
-end
-
----Gets a list of all online players of a specified job and the number, with an option to check if they are on duty.
----@param job string
----@param checkOnDuty boolean
----@return table, number
-function QBCore.Functions.GetPlayersByJobName(job, checkOnDuty)
-    local players = {}
-    local count = 0
-    for src, Player in pairs(QBCore.Players) do
-        if Player.PlayerData.job.name == job then
-            if checkOnDuty then
-                if Player.PlayerData.job.onduty then
-                    players[#players + 1] = src
-                    count += 1
-                end
-            else
-                players[#players + 1] = src
-                count += 1
-            end
-        end
-    end
-    return players, count
-end
-
----Gets a list of all online players with a specified job type and the number, with an option to check if they are on duty.
----@param jobType string
----@param checkOnDuty boolean
----@return table, number
-function QBCore.Functions.GetPlayersByJobType(jobType, checkOnDuty)
-    local players = {}
-    local count = 0
-    for src, Player in pairs(QBCore.Players) do
-        if Player.PlayerData.job.type == jobType then
-            if checkOnDuty then
-                if Player.PlayerData.job.onduty then
-                    players[#players + 1] = src
-                    count += 1
-                end
-            else
-                players[#players + 1] = src
-                count += 1
-            end
-        end
-    end
+    local players, count = QBCore.Functions.GetPlayersByJob(job, true)
     return players, count
 end
 
@@ -199,14 +167,7 @@ end
 ---@param job string
 ---@return number
 function QBCore.Functions.GetDutyCount(job)
-    local count = 0
-    for _, Player in pairs(QBCore.Players) do
-        if Player.PlayerData.job.name == job then
-            if Player.PlayerData.job.onduty then
-                count += 1
-            end
-        end
-    end
+    local _, count = QBCore.Functions.GetPlayersByJob(job, true)
     return count
 end
 


### PR DESCRIPTION
## Description

Adds two utility functions to retrieve online players by either job name or job type, with optional filtering for on-duty status. While the logic is a bit nested, this approach avoids unnecessary function splitting and keeps related behavior in a single place. Although I'm not entirely satisfied with the nesting, this structure felt like a reasonable trade-off between readability and reusability.

This method could also serve as a foundation for deprecating older job-check functions, should the maintainer choose to consolidate similar logic in the future.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [] My code fits the style guidelines. 
- [ ] My PR fits the contribution guidelines. 
