### PR TITLE
Fix Broken Windows Json

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -651,7 +651,7 @@ function QBCore.Functions.SetVehicleProperties(vehicle, props)
         end
         if props.windowStatus then
             for windowIndex, smashWindow in pairs(props.windowStatus) do
-                if not smashWindow then SmashVehicleWindow(vehicle, windowIndex) end
+                if not smashWindow then SmashVehicleWindow(vehicle, tonumber(windowIndex)) end
             end
         end
         if props.doorStatus then


### PR DESCRIPTION
## Description
When performing a json.encode to save in the database and then a json.decode, the windows do not break because the windowIndex is not a number.

## Checklist
- [X] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
