### PR TITLE
Add option to store player fields in PlayerData

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -410,8 +410,12 @@ function QBCore.Player.CreatePlayer(PlayerData, Offline)
         self.Functions[methodName] = handler
     end
 
-    function self.Functions.AddField(fieldName, data)
-        self[fieldName] = data
+    function self.Functions.AddField(fieldName, data, inPlayerData)
+        if inPlayerData then
+            self.PlayerData[fieldName] = data
+        else
+            self[fieldName] = data
+        end
     end
 
     if self.Offline then
@@ -461,21 +465,21 @@ end
     end)
 ]]
 
-function QBCore.Functions.AddPlayerField(ids, fieldName, data)
+function QBCore.Functions.AddPlayerField(ids, fieldName, data, inPlayerData)
     local idType = type(ids)
     if idType == 'number' then
         if ids == -1 then
             for _, v in pairs(QBCore.Players) do
-                v.Functions.AddField(fieldName, data)
+                v.Functions.AddField(fieldName, data, inPlayerData)
             end
         else
             if not QBCore.Players[ids] then return end
 
-            QBCore.Players[ids].Functions.AddField(fieldName, data)
+            QBCore.Players[ids].Functions.AddField(fieldName, data, inPlayerData)
         end
     elseif idType == 'table' and table.type(ids) == 'array' then
         for i = 1, #ids do
-            QBCore.Functions.AddPlayerField(ids[i], fieldName, data)
+            QBCore.Functions.AddPlayerField(ids[i], fieldName, data, inPlayerData)
         end
     end
 end


### PR DESCRIPTION
## Description

Updated AddField and AddPlayerField functions to support storing fields in the PlayerData table when the inPlayerData flag is set. This allows for more flexible management of player attributes.

Currently you will have to do:

```lua
local newPlayerData = Player.PlayerData
newPlayerData['newData'] = 'This is new Data'
Player.AddField('PlayerData', newPlayerData)
```

With this chage you will only have to do:

```lua
Player.AddField('newData', 'This is new Data', true)
```

## Checklist

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
