### PR TITLE
add qbconfig_server_* convar

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ### [Official QBCore Documentation](https://docs.qbcore.org)
 
+## Setup
+
+To change database connection settings, add [`setr qbconfig_server_hostname` or equivalent](https://qbcore.net/quickstart#step-4-configure-qbcore).
+
 # License
 
     QBCore Framework

--- a/config.lua
+++ b/config.lua
@@ -155,3 +155,11 @@ QBConfig.Notify.VariantDefinitions = {
         icon = 'fas fa-ambulance'
     }
 }
+
+
+QBConfig.Server.hostname = GetConvar("qbconfig_server_hostname", "localhost")
+QBConfig.Server.username = GetConvar("qbconfig_server_username", "root")
+QBConfig.Server.password = GetConvar("qbconfig_server_password", "root")
+QBConfig.Server.database = GetConvar("qbconfig_server_database", "qbcore")
+QBConfig.Server.port = GetConvarInt("qbconfig_server_port", 3306)
+


### PR DESCRIPTION
## Description

Add `qbconfig_server_*` convar to avoid having to modify config.lua

## Checklist

- [ ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.

## Notes

I'm not sure whether [this configuration](https://qbcore.net/quickstart#step-4-configure-qbcore) is even used

I couldn't find the problematic document in GitHub
