### PR TITLE
feat: further exports of player related functionalities

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ game 'gta5'
 lua54 'yes'
 author 'Kakarot'
 description 'Core resource for the framework, contains all the core functionality and features'
-version '1.3.0'
+version '1.4.0'
 
 shared_scripts {
     'config.lua',

--- a/server/exports.lua
+++ b/server/exports.lua
@@ -334,3 +334,29 @@ local function ExploitBan(playerId, origin)
 end
 
 exports('ExploitBan', ExploitBan)
+
+-- Exports for the player functions/object
+local playerFunctions = {
+    AddPlayerMoney = "AddMoney",
+    RemovePlayerMoney = "RemoveMoney"
+}
+
+for exportName, functionName in pairs(playerFunctions) do
+    exports(exportName, function(identifier, ...)
+        if not type(identifier) == "string" then
+            warn("Identifier has to be a string")
+            return false
+        end
+
+        local plr = QBCore.Functions.GetPlayerByCitizenId(identifier)
+
+        if plr then
+            if not type(plr.Functions[functionName]) == "function" then
+                warn("Something went wrong, could not find/execute the player function")
+                return false
+            end
+
+            return plr.Functions[functionName](...)
+        end
+    end)
+end


### PR DESCRIPTION
## Description
The idea of this is mainly from chats in the qbcore discord. I am opening this draft PR so we can all work together on implementing this.

The main goal of the PR is to export main player functions, such as adding items, giving money, and all of those sorts of things.

## Todo/Known issues
- Offline player handling?
> We could perhaps use `GetOfflinePlayer`, but I'm not entirely sure majority of the exports work in that case? This is something we need to test
- Is there a better way than having the in-place `playerFunctions` variable?
- If not (^^^^): Add all of the functions to the `playerFunctions` map
- Test all exports & functionality

## Checklist
- [ ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
