### PR TITLE
Fix health metadata not saving on reconnect

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -4,6 +4,21 @@
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     ShutdownLoadingScreenNui()
     LocalPlayer.state:set('isLoggedIn', true, false)
+
+    -- Restore saved health and armor after ped is ready
+    CreateThread(function()
+        Wait(1000) -- Wait for ped to be fully spawned
+        local ped = PlayerPedId()
+        local health = QBCore.PlayerData.metadata['health']
+        local armor = QBCore.PlayerData.metadata['armor']
+        if health and health > 0 then
+            SetEntityHealth(ped, health)
+        end
+        if armor and armor > 0 then
+            SetPedArmour(ped, armor)
+        end
+    end)
+
     if not QBCore.Config.Server.PVP then return end
     SetCanAttackFriendly(PlayerPedId(), true, false)
     NetworkSetFriendlyFireOption(true)

--- a/client/loops.lua
+++ b/client/loops.lua
@@ -3,7 +3,10 @@ CreateThread(function()
         local sleep = 0
         if LocalPlayer.state.isLoggedIn then
             sleep = (1000 * 60) * QBCore.Config.UpdateInterval
-            TriggerServerEvent('QBCore:UpdatePlayer')
+            local ped = PlayerPedId()
+            local health = GetEntityHealth(ped)
+            local armor = GetPedArmour(ped)
+            TriggerServerEvent('QBCore:UpdatePlayer', health, armor)
         end
         Wait(sleep)
     end

--- a/config.lua
+++ b/config.lua
@@ -67,6 +67,7 @@ QBConfig.Player.PlayerDefaults = {
         isdead = false,
         inlaststand = false,
         armor = 0,
+        health = 200,
         ishandcuffed = false,
         tracker = false,
         injail = 0,

--- a/server/events.lua
+++ b/server/events.lua
@@ -11,6 +11,11 @@ AddEventHandler('playerDropped', function(reason)
     local src = source
     if not QBCore.Players[src] then return end
     local Player = QBCore.Players[src]
+    local ped = GetPlayerPed(src)
+    if ped and DoesEntityExist(ped) then
+        Player.Functions.SetMetaData('health', GetEntityHealth(ped))
+        Player.Functions.SetMetaData('armor', GetPedArmour(ped))
+    end
     TriggerEvent('qb-log:server:CreateLog', 'joinleave', 'Dropped', 'red', '**' .. GetPlayerName(src) .. '** (' .. Player.PlayerData.license .. ') left..' .. '\n **Reason:** ' .. reason)
     TriggerEvent('QBCore:Server:PlayerDropped', Player)
     Player.Functions.Save()
@@ -149,7 +154,7 @@ end)
 
 -- Player
 
-RegisterNetEvent('QBCore:UpdatePlayer', function()
+RegisterNetEvent('QBCore:UpdatePlayer', function(health, armor)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     if not Player then return end
@@ -163,6 +168,12 @@ RegisterNetEvent('QBCore:UpdatePlayer', function()
     end
     Player.Functions.SetMetaData('thirst', newThirst)
     Player.Functions.SetMetaData('hunger', newHunger)
+    if health then
+        Player.Functions.SetMetaData('health', health)
+    end
+    if armor then
+        Player.Functions.SetMetaData('armor', armor)
+    end
     TriggerClientEvent('hud:client:UpdateNeeds', src, newHunger, newThirst)
     Player.Functions.Save()
 end)


### PR DESCRIPTION
## Summary

Fixes player health resetting to full on reconnect by properly saving and restoring health metadata.

## Problem

When players disconnect and reconnect, their health resets to full instead of being preserved. This happens because:
1. No `health` field existed in the default metadata
2. Health was never captured from the client
3. Health was never saved to the database
4. Health was never restored on spawn

## Solution

**config.lua**
- Added `health = 200` to default player metadata

**client/loops.lua**
- Modified `QBCore:UpdatePlayer` to send current health and armor to server

**server/events.lua**
- Modified `QBCore:UpdatePlayer` handler to save received health/armor to metadata
- Modified `playerDropped` handler to capture health/armor before saving on disconnect

**client/events.lua**
- Added health/armor restoration in `OnPlayerLoaded` event

## Testing

Tested using [LuaGround](https://github.com/AndyBodnar/LuaGround) - all metadata persistence tests pass.

## Related Issue

Fixes #1213