### PR TITLE
feat(player): include previous job and gang data in update events

### DIFF
--- a/server/events.lua
+++ b/server/events.lua
@@ -178,9 +178,6 @@ RegisterNetEvent('QBCore:ToggleDuty', function()
         Player.Functions.SetJobDuty(true)
         TriggerClientEvent('QBCore:Notify', src, Lang:t('info.on_duty'))
     end
-
-    TriggerEvent('QBCore:Server:SetDuty', src, Player.PlayerData.job.onduty)
-    TriggerClientEvent('QBCore:Client:SetDuty', src, Player.PlayerData.job.onduty)
 end)
 
 -- BaseEvents

--- a/server/player.lua
+++ b/server/player.lua
@@ -271,10 +271,9 @@ function QBCore.Player.CreatePlayer(PlayerData, Offline)
     end
 
     function self.Functions.SetJobDuty(onDuty)
-        local lastJob = self.PlayerData.job
         self.PlayerData.job.onduty = not not onDuty
-        TriggerEvent('QBCore:Server:OnJobUpdate', self.PlayerData.source, self.PlayerData.job, lastJob)
-        TriggerClientEvent('QBCore:Client:OnJobUpdate', self.PlayerData.source, self.PlayerData.job, lastJob)
+        TriggerEvent('QBCore:Server:SetDuty', self.PlayerData.source, self.PlayerData.job.onduty)
+        TriggerClientEvent('QBCore:Client:SetDuty', self.PlayerData.source, self.PlayerData.job.onduty)
         self.Functions.UpdatePlayerData('job', self.PlayerData.job)
     end
 

--- a/server/player.lua
+++ b/server/player.lua
@@ -193,6 +193,7 @@ function QBCore.Player.CreatePlayer(PlayerData, Offline)
         job = job:lower()
         grade = grade or '0'
         if not QBCore.Shared.Jobs[job] then return false end
+        local lastJob = self.PlayerData.job
         self.PlayerData.job = {
             name = job,
             label = QBCore.Shared.Jobs[job].label,
@@ -217,8 +218,8 @@ function QBCore.Player.CreatePlayer(PlayerData, Offline)
 
         if not self.Offline then
             self.Functions.UpdatePlayerData('job', self.PlayerData.job)
-            TriggerEvent('QBCore:Server:OnJobUpdate', self.PlayerData.source, self.PlayerData.job)
-            TriggerClientEvent('QBCore:Client:OnJobUpdate', self.PlayerData.source, self.PlayerData.job)
+            TriggerEvent('QBCore:Server:OnJobUpdate', self.PlayerData.source, self.PlayerData.job, lastJob)
+            TriggerClientEvent('QBCore:Client:OnJobUpdate', self.PlayerData.source, self.PlayerData.job, lastJob)
         end
 
         return true
@@ -228,6 +229,7 @@ function QBCore.Player.CreatePlayer(PlayerData, Offline)
         gang = gang:lower()
         grade = grade or '0'
         if not QBCore.Shared.Gangs[gang] then return false end
+        local lastGang = self.PlayerData.gang
         self.PlayerData.gang = {
             name = gang,
             label = QBCore.Shared.Gangs[gang].label,
@@ -248,8 +250,8 @@ function QBCore.Player.CreatePlayer(PlayerData, Offline)
 
         if not self.Offline then
             self.Functions.UpdatePlayerData('gang', self.PlayerData.gang)
-            TriggerEvent('QBCore:Server:OnGangUpdate', self.PlayerData.source, self.PlayerData.gang)
-            TriggerClientEvent('QBCore:Client:OnGangUpdate', self.PlayerData.source, self.PlayerData.gang)
+            TriggerEvent('QBCore:Server:OnGangUpdate', self.PlayerData.source, self.PlayerData.gang, lastGang)
+            TriggerClientEvent('QBCore:Client:OnGangUpdate', self.PlayerData.source, self.PlayerData.gang, lastGang)
         end
 
         return true
@@ -269,9 +271,10 @@ function QBCore.Player.CreatePlayer(PlayerData, Offline)
     end
 
     function self.Functions.SetJobDuty(onDuty)
+        local lastJob = self.PlayerData.job
         self.PlayerData.job.onduty = not not onDuty
-        TriggerEvent('QBCore:Server:OnJobUpdate', self.PlayerData.source, self.PlayerData.job)
-        TriggerClientEvent('QBCore:Client:OnJobUpdate', self.PlayerData.source, self.PlayerData.job)
+        TriggerEvent('QBCore:Server:OnJobUpdate', self.PlayerData.source, self.PlayerData.job, lastJob)
+        TriggerClientEvent('QBCore:Client:OnJobUpdate', self.PlayerData.source, self.PlayerData.job, lastJob)
         self.Functions.UpdatePlayerData('job', self.PlayerData.job)
     end
 


### PR DESCRIPTION
## Description

Adds previous state tracking to player job and gang updates by passing lastJob and lastGang to server and client events.

This provides downstream resources with access to both the old and new state, improving flexibility for event-driven logic without requiring additional state tracking.

The change is backward compatible, as existing handlers can ignore the extra argument.

Additionally refactors duty handling by moving SetDuty event triggering into SetJobDuty. Previously, these events were only fired when using ToggleDuty; now they are consistently triggered whenever duty is changed via SetJobDuty.

Applies to:
- QBCore:Server:OnJobUpdate
- QBCore:Client:OnJobUpdate
- Gang update equivalents
- QBCore:Server:SetDuty
- QBCore:Client:SetDuty