### PR TITLE
feat(commands): add pre-execution middleware event

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -21,6 +21,10 @@ function QBCore.Commands.Add(name, help, arguments, argsrequired, callback, perm
     if permission == 'user' then restricted = false end      -- allow all users to use command
 
     RegisterCommand(name, function(source, args, rawCommand) -- Register command within fivem
+
+        TriggerEvent('QBCore:Server:PreCommandExecution', source, name, args, rawCommand)
+        if WasEventCanceled() then return end
+
         if argsrequired and #args < #arguments then
             return TriggerClientEvent('chat:addMessage', source, {
                 color = { 255, 0, 0 },

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -21,10 +21,6 @@ function QBCore.Commands.Add(name, help, arguments, argsrequired, callback, perm
     if permission == 'user' then restricted = false end      -- allow all users to use command
 
     RegisterCommand(name, function(source, args, rawCommand) -- Register command within fivem
-
-        TriggerEvent('QBCore:Server:PreCommandExecution', source, name, args, rawCommand)
-        if WasEventCanceled() then return end
-
         if argsrequired and #args < #arguments then
             return TriggerClientEvent('chat:addMessage', source, {
                 color = { 255, 0, 0 },
@@ -32,6 +28,10 @@ function QBCore.Commands.Add(name, help, arguments, argsrequired, callback, perm
                 args = { 'System', Lang:t('error.missing_args2') }
             })
         end
+
+        TriggerEvent('QBCore:Server:PreCommandExecution', source, name, args, rawCommand)
+        if WasEventCanceled() then return end
+
         callback(source, args, rawCommand)
     end, restricted)
 


### PR DESCRIPTION
## Description

Added the `QBCore:Server:PreCommandExecution` event inside `QBCore.Commands.Add`, triggering just before the command callback. 

This allows developers to easily create middleware (e.g., for custom logging or anti-cheat checks) and stop command execution using `CancelEvent()` without having to modify core files.

## Checklist

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.