### PR TITLE
🐛 Fix race condition causing ghost characters on deletion

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -575,7 +575,11 @@ function QBCore.Player.ForceDeleteCharacter(citizenid)
     local queries  = {}
     local existing = QBCore.Functions.GetPlayerByCitizenId(citizenid)
     if existing then
-        DropPlayer(existing.PlayerData.source, 'An admin deleted the character which you are currently using')
+        local src = existing.PlayerData.source
+        -- clear refs to prevent playerDropped from saving
+        QBCore.Players[src] = nil 
+        QBCore.PlayersByCitizenId[citizenid] = nil
+        DropPlayer(src, 'An admin deleted the character which you are currently using')
     end
     for i = 1, #playertables do
         queries[i] = { query = query:format(playertables[i].table), values = { citizenid } }

--- a/server/player.lua
+++ b/server/player.lua
@@ -577,7 +577,7 @@ function QBCore.Player.ForceDeleteCharacter(citizenid)
     if existing then
         local src = existing.PlayerData.source
         -- clear refs to prevent playerDropped from saving
-        QBCore.Players[src] = nil 
+        QBCore.Players[src] = nil
         QBCore.PlayersByCitizenId[citizenid] = nil
         DropPlayer(src, 'An admin deleted the character which you are currently using')
     end


### PR DESCRIPTION
## Description

this PR fixes a race condition in `QBCore.Player.ForceDeleteCharacter` that causes deleted characters to glitch out and become "ghosts" in the db

**The Issue:**
if an admin force deletes a character while the player is activly connected, the script calls `DropPlayer()`, this instantly fires the `playerDropped` event which triggers an async `player.Functions.Save()` but simultaneously, the original function is running the async `DELETE` 

because `oxmysql` handles both asynchronously the `DELETE` usually finishes a split second *before* the `INSERT` save finishes so he character's tables get wiped cleanly but the save query instantly brings their main entry back into the `players` table

when that player logs back in they load right into a broken character this causes severe `nil` value spam in the server console every time the framework tries to fetch their missing data which completely tanks server performance until the ghost entry is manually purged from the DB

**The Fix:**
i simply nulled the `QBCore.Players` and `QBCore.PlayersByCitizenId` references *before* calling `DropPlayer()` this ensures the drop event fails its existence check aborts the final save and lets the main `DELETE` finish cleanlly

**Steps to Reproduce / Verify:**
1. have a player connect and load into a character
2. run the force delete command/function on their `citizenid` while they are online
3. **wthout the fix:** the player drops, but their character entry is instantly recreated in the `players` table
4. **with the fix:** the player drops and the character is fully wiped from all tables.

## Checklist
- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.